### PR TITLE
Fix for installing aws.lambda.tools along side nuget.config with priv…

### DIFF
--- a/.changes/next-release/Bug Fix-0d02e676-f277-4883-bea5-70eb36a76cef.json
+++ b/.changes/next-release/Bug Fix-0d02e676-f277-4883-bea5-70eb36a76cef.json
@@ -1,0 +1,4 @@
+{
+    "type": "Bug Fix",
+    "description": "Fix for installing aws.lambda.tools along side nuget.config with private nuget-feed."
+}

--- a/Tasks/Common/dotNetCliWrapper.ts
+++ b/Tasks/Common/dotNetCliWrapper.ts
@@ -48,7 +48,15 @@ export class DotNetCliWrapper {
 
     private async updateGlobalTools(): Promise<boolean> {
         try {
-            const returnCode = await this.execute(['tool', 'update', '-g', 'Amazon.Lambda.Tools'], '')
+            const returnCode = await this.execute(
+                [
+                    'tool',
+                    'update',
+                    "-g --ignore-failed-sourced --add-source https://api.nuget.org/v3/index.json --version '*'",
+                    'Amazon.Lambda.Tools'
+                ],
+                ''
+            )
             if (returnCode === 0) {
                 return true
             } else {
@@ -65,7 +73,15 @@ export class DotNetCliWrapper {
 
     private async installGlobalTools(): Promise<boolean> {
         try {
-            const returnCode = await this.execute(['tool', 'install', '-g', 'Amazon.Lambda.Tools'], '')
+            const returnCode = await this.execute(
+                [
+                    'tool',
+                    'install',
+                    "-g --ignore-failed-sourced --add-source https://api.nuget.org/v3/index.json --version '*'",
+                    'Amazon.Lambda.Tools'
+                ],
+                ''
+            )
             if (returnCode === 0) {
                 return true
             } else {


### PR DESCRIPTION
…ate feed.

This change will always allow aws.lambda.tools to be installed in the buildpipeline regardless of the presence of a private feed in the nuget config.

<!--- Provide a general summary of your changes in the Title above -->

## Description

I changed the installation command from 
dotnet install aws.lambda.tools 
to
dotnet install -g --ignore-failed-sourced --add-source https://api.nuget.org/v3/index.json --version '*'

<!--- Describe your changes in detail -->

## Motivation

The installation will fail if you have a nuget.config file with a private feed in it. See tickets: 
https://github.com/dotnet/sdk/issues/9555

To replicate the issue, try to build any lambda project, with a nuget.config file with a private feed listed. 

<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s), If Filed
https://github.com/dotnet/sdk/issues/9555

Related to tickets where the user is unable to use the pipeline 
https://github.com/aws/aws-toolkit-azure-devops/issues/354
https://github.com/aws/aws-toolkit-azure-devops/issues/350

There is the possibility to add a version number to the aws.lambda.tools installation command, so we can force it on 4.0.0, and avoid it loading a older version from a private feed. But by selecting version '*' we keep the same version selection logic as today, and don't change that part.

<!--- What is the related issue you are trying to fix? -->

## Testing

I have replicated the installation process on my own PC, by simply running the dotnet install command along side a nuget.config package. 
I don't have access to a private devops setup. So I have not been able to verify the setup live. 
**Can someone help test this on a devops pipeline before merging?**



<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [X] I have read the **README** document
-   [X] I have read the **CONTRIBUTING** document
-   [X] My code follows the code style of this project
-   [-] I have added tests to cover my changes
-   [X] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
