### PR TITLE
Add enforceDockerNamingConventions to ECRPushImage

### DIFF
--- a/.changes/next-release/Feature-ae9e0065-3fe4-4f9f-a812-409097f2ebe9.json
+++ b/.changes/next-release/Feature-ae9e0065-3fe4-4f9f-a812-409097f2ebe9.json
@@ -1,4 +1,4 @@
 {
     "type": "Feature",
-    "description": "Add enforceDockerNamingConventions to ECRPushImage"
+    "description": "Add checkbox option to ECR Push task that forces the repo name to adhere to Docker naming conventions (#357)"
 }

--- a/.changes/next-release/Feature-ae9e0065-3fe4-4f9f-a812-409097f2ebe9.json
+++ b/.changes/next-release/Feature-ae9e0065-3fe4-4f9f-a812-409097f2ebe9.json
@@ -1,0 +1,4 @@
+{
+    "type": "Feature",
+    "description": "Add enforceDockerNamingConventions to ECRPushImage"
+}

--- a/Tasks/ECRPushImage/TaskOperations.ts
+++ b/Tasks/ECRPushImage/TaskOperations.ts
@@ -24,7 +24,7 @@ export class TaskOperations {
 
         let sourceImageRef: string
 
-        if (this.taskParameters.enforceDockerNamingConventions) {
+        if (this.taskParameters.forceDockerNamingConventions) {
             // The repository name can only contain lowercase letters, numbers, or - and _.
             this.taskParameters.repositoryName = this.taskParameters.repositoryName
                 .toLowerCase()

--- a/Tasks/ECRPushImage/TaskOperations.ts
+++ b/Tasks/ECRPushImage/TaskOperations.ts
@@ -23,6 +23,14 @@ export class TaskOperations {
         this.dockerPath = await this.dockerHandler.locateDockerExecutable()
 
         let sourceImageRef: string
+
+        if (this.taskParameters.enforceDockerNamingConventions) {
+            // The repository name can only contain lowercase letters, numbers, or - and _.
+            this.taskParameters.repositoryName = this.taskParameters.repositoryName
+                .toLowerCase()
+                .replace(/[^a-z0-9-_.]/g, '')
+        }
+
         if (this.taskParameters.imageSource === imageNameSource) {
             sourceImageRef = constructTaggedImageName(
                 this.taskParameters.sourceImageName,

--- a/Tasks/ECRPushImage/TaskParameters.ts
+++ b/Tasks/ECRPushImage/TaskParameters.ts
@@ -19,6 +19,7 @@ export interface TaskParameters {
     repositoryName: string
     pushTag: string
     autoCreateRepository: boolean
+    enforceDockerNamingConventions: boolean
     outputVariable: string
 }
 
@@ -29,6 +30,7 @@ export function buildTaskParameters(): TaskParameters {
         repositoryName: getInputRequired('repositoryName'),
         pushTag: getInputOrEmpty('pushTag'),
         autoCreateRepository: tl.getBoolInput('autoCreateRepository', false),
+        enforceDockerNamingConventions: tl.getBoolInput('enforceDockerNamingConventions', false),
         outputVariable: getInputOrEmpty('outputVariable'),
         sourceImageName: '',
         sourceImageId: '',

--- a/Tasks/ECRPushImage/TaskParameters.ts
+++ b/Tasks/ECRPushImage/TaskParameters.ts
@@ -19,7 +19,7 @@ export interface TaskParameters {
     repositoryName: string
     pushTag: string
     autoCreateRepository: boolean
-    enforceDockerNamingConventions: boolean
+    forceDockerNamingConventions: boolean
     outputVariable: string
 }
 
@@ -30,7 +30,7 @@ export function buildTaskParameters(): TaskParameters {
         repositoryName: getInputRequired('repositoryName'),
         pushTag: getInputOrEmpty('pushTag'),
         autoCreateRepository: tl.getBoolInput('autoCreateRepository', false),
-        enforceDockerNamingConventions: tl.getBoolInput('enforceDockerNamingConventions', false),
+        forceDockerNamingConventions: tl.getBoolInput('forceDockerNamingConventions', false),
         outputVariable: getInputOrEmpty('outputVariable'),
         sourceImageName: '',
         sourceImageId: '',

--- a/Tasks/ECRPushImage/task.json
+++ b/Tasks/ECRPushImage/task.json
@@ -110,7 +110,7 @@
             "helpMarkDown": "If selected the task will attempt to create the repository if it does not exist."
         },
         {
-            "name": "enforceDockerNamingConventions",
+            "name": "forceDockerNamingConventions",
             "label": "Force repository name to follow Docker naming conventions",
             "type": "boolean",
             "defaultValue": false,

--- a/Tasks/ECRPushImage/task.json
+++ b/Tasks/ECRPushImage/task.json
@@ -110,6 +110,14 @@
             "helpMarkDown": "If selected the task will attempt to create the repository if it does not exist."
         },
         {
+            "name": "enforceDockerNamingConventions",
+            "label": "Force repository name to follow Docker naming conventions",
+            "type": "boolean",
+            "defaultValue": false,
+            "required": false,
+            "helpMarkDown": "If enabled, the Docker repository name will be modified to follow Docker naming conventions. Converts upper case characters to lower case. Removes all characters except 0-9, -, . and _ ."
+        },
+        {
             "name": "outputVariable",
             "type": "string",
             "label": "Image Tag Output Variable",

--- a/tests/taskTests/ecrPushImage/ecrPushImage-test.ts
+++ b/tests/taskTests/ecrPushImage/ecrPushImage-test.ts
@@ -23,6 +23,7 @@ const defaultTaskParameters: TaskParameters = {
     repositoryName: '',
     pushTag: '',
     autoCreateRepository: false,
+    enforceDockerNamingConventions: false,
     outputVariable: ''
 }
 
@@ -138,5 +139,53 @@ describe('ECR Push image', () => {
         expect(ecr.getAuthorizationToken).toBeCalledTimes(1)
         expect(ecr.describeRepositories).toBeCalledTimes(1)
         expect(runDockerCommand.mock.calls[0][2]).toStrictEqual(['', 'example.com/name'])
+    })
+
+    test('Docker naming conventions; replace uppercase', async () => {
+        expect.assertions(1)
+        const dockerHandler = { ...defaultDocker }
+        const runDockerCommand = jest.fn(async (thing1, thing2, thing3) => undefined)
+        dockerHandler.runDockerCommand = runDockerCommand
+        const ecr = new ECR() as any
+        ecr.getAuthorizationToken = jest.fn(() => ecrReturnsToken)
+        ecr.describeRepositories = jest.fn(() => ecrFailNotFound)
+        const taskParameters = { ...defaultTaskParameters }
+        taskParameters.enforceDockerNamingConventions = true
+        taskParameters.repositoryName = 'RepoName'
+        const taskOperations = new TaskOperations(ecr, dockerHandler, taskParameters)
+        await taskOperations.execute()
+        expect(runDockerCommand.mock.calls[0][2]).toStrictEqual(['', 'example.com/reponame'])
+    })
+
+    test('Docker naming conventions; keep valid characters', async () => {
+        expect.assertions(1)
+        const dockerHandler = { ...defaultDocker }
+        const runDockerCommand = jest.fn(async (thing1, thing2, thing3) => undefined)
+        dockerHandler.runDockerCommand = runDockerCommand
+        const ecr = new ECR() as any
+        ecr.getAuthorizationToken = jest.fn(() => ecrReturnsToken)
+        ecr.describeRepositories = jest.fn(() => ecrFailNotFound)
+        const taskParameters = { ...defaultTaskParameters }
+        taskParameters.enforceDockerNamingConventions = true
+        taskParameters.repositoryName = 'my-repo.name_01'
+        const taskOperations = new TaskOperations(ecr, dockerHandler, taskParameters)
+        await taskOperations.execute()
+        expect(runDockerCommand.mock.calls[0][2]).toStrictEqual(['', 'example.com/my-repo.name_01'])
+    })
+
+    test('Docker naming conventions; remove invalid characters', async () => {
+        expect.assertions(1)
+        const dockerHandler = { ...defaultDocker }
+        const runDockerCommand = jest.fn(async (thing1, thing2, thing3) => undefined)
+        dockerHandler.runDockerCommand = runDockerCommand
+        const ecr = new ECR() as any
+        ecr.getAuthorizationToken = jest.fn(() => ecrReturnsToken)
+        ecr.describeRepositories = jest.fn(() => ecrFailNotFound)
+        const taskParameters = { ...defaultTaskParameters }
+        taskParameters.enforceDockerNamingConventions = true
+        taskParameters.repositoryName = 'm!y@r #e$p%o^n&a*m(e)'
+        const taskOperations = new TaskOperations(ecr, dockerHandler, taskParameters)
+        await taskOperations.execute()
+        expect(runDockerCommand.mock.calls[0][2]).toStrictEqual(['', 'example.com/myreponame'])
     })
 })

--- a/tests/taskTests/ecrPushImage/ecrPushImage-test.ts
+++ b/tests/taskTests/ecrPushImage/ecrPushImage-test.ts
@@ -23,7 +23,7 @@ const defaultTaskParameters: TaskParameters = {
     repositoryName: '',
     pushTag: '',
     autoCreateRepository: false,
-    enforceDockerNamingConventions: false,
+    forceDockerNamingConventions: false,
     outputVariable: ''
 }
 
@@ -150,7 +150,7 @@ describe('ECR Push image', () => {
         ecr.getAuthorizationToken = jest.fn(() => ecrReturnsToken)
         ecr.describeRepositories = jest.fn(() => ecrFailNotFound)
         const taskParameters = { ...defaultTaskParameters }
-        taskParameters.enforceDockerNamingConventions = true
+        taskParameters.forceDockerNamingConventions = true
         taskParameters.repositoryName = 'RepoName'
         const taskOperations = new TaskOperations(ecr, dockerHandler, taskParameters)
         await taskOperations.execute()
@@ -166,7 +166,7 @@ describe('ECR Push image', () => {
         ecr.getAuthorizationToken = jest.fn(() => ecrReturnsToken)
         ecr.describeRepositories = jest.fn(() => ecrFailNotFound)
         const taskParameters = { ...defaultTaskParameters }
-        taskParameters.enforceDockerNamingConventions = true
+        taskParameters.forceDockerNamingConventions = true
         taskParameters.repositoryName = 'my-repo.name_01'
         const taskOperations = new TaskOperations(ecr, dockerHandler, taskParameters)
         await taskOperations.execute()
@@ -182,7 +182,7 @@ describe('ECR Push image', () => {
         ecr.getAuthorizationToken = jest.fn(() => ecrReturnsToken)
         ecr.describeRepositories = jest.fn(() => ecrFailNotFound)
         const taskParameters = { ...defaultTaskParameters }
-        taskParameters.enforceDockerNamingConventions = true
+        taskParameters.forceDockerNamingConventions = true
         taskParameters.repositoryName = 'm!y@r #e$p%o^n&a*m(e)'
         const taskOperations = new TaskOperations(ecr, dockerHandler, taskParameters)
         await taskOperations.execute()


### PR DESCRIPTION
## Description

Added a checkbox to the ECR Push task that forces the repo name to adhere to Docker naming conventions. Uppercase characters are converted to lowercase and invalid characters are removed.

## Motivation

It removes the need to enforce repo naming conventions on the source repo and allows for greater flexibility in dev workflows. It also avoids the need for an additional task in the pipeline to convert the repo name to a valid name before pushing

## Related Issue(s), If Filed

[#357 - Feature Request - Option in ECR Push task to force repo name to conform to Docker specs](https://github.com/aws/aws-toolkit-azure-devops/issues/357)

## Testing

1. I changed the code and ran the original tests, all passed.
1. Added a Happy Path that basically mimicked the original Happy Path unit test, with the addition of ```taskParameters.enforceDockerNamingConventions = true```, all passed.
1. Expanded on this duplicated unit test to include 3 scenarios;
    1. Replacing uppercase with lowercase.
    1. Keeping valid characters.
    1. Removing invalid characters. **Note: this was a basic sanity test and does not include all available invalid characters.**

**Help Needed: I was not able to verify this change live. It would be awesome if someone could assist with this.**

## Checklist

-   [ x ] I have read the **README** document
-   [ x ] I have read the **CONTRIBUTING** document
-   [ x ] My code follows the code style of this project
-   [ x ] I have added tests to cover my changes
-   [ x ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
