### PR TITLE
Update user agent to have AZDO agent version

### DIFF
--- a/Tasks/Common/sdkutils.ts
+++ b/Tasks/Common/sdkutils.ts
@@ -38,18 +38,18 @@ export abstract class SdkUtils {
     // Injects a custom user agent conveying extension version and task being run into the
     // sdk so usage metrics can be tied to the tools.
     public static setSdkUserAgentFromManifest(taskManifestFilePath: string): void {
-        if (fs.existsSync(taskManifestFilePath)) {
-            const taskManifest = JSON.parse(fs.readFileSync(taskManifestFilePath, 'utf8')) as VSTSTaskManifest
-            const version = taskManifest.version
-            const userAgentString = `${this.userAgentPrefix}/${version.Major}.${version.Minor}.${version.Patch} ${
-                    this.userAgentSuffix
-                }-${taskManifest.name}`
-                // tslint:disable-next-line:whitespace align
-            ;((AWS as any).util as any).userAgent = () => {
-                return userAgentString
-            }
-        } else {
+        if (!fs.existsSync(taskManifestFilePath)) {
             console.warn(`Task manifest ${taskManifestFilePath} not found, cannot set custom user agent!`)
+
+            return
+        }
+        const taskManifest = JSON.parse(fs.readFileSync(taskManifestFilePath, 'utf8')) as VSTSTaskManifest
+        const version = taskManifest.version
+        const agentVersion = tl.getVariable('agent.version') ?? 'unknown'
+        const userAgentString = `${this.userAgentPrefix}/${version.Major}.${version.Minor}.${version.Patch} ${this.userAgentSuffix}-${agentVersion}-${taskManifest.name}`
+            // tslint:disable-next-line:whitespace align
+        ;((AWS as any).util as any).userAgent = () => {
+            return userAgentString
         }
     }
 

--- a/Tasks/Common/sdkutils.ts
+++ b/Tasks/Common/sdkutils.ts
@@ -43,11 +43,12 @@ export abstract class SdkUtils {
 
             return
         }
+
         const taskManifest = JSON.parse(fs.readFileSync(taskManifestFilePath, 'utf8')) as VSTSTaskManifest
         const version = taskManifest.version
         const agentVersion = tl.getVariable('agent.version') ?? 'unknown'
         const userAgentString = `${this.userAgentPrefix}/${version.Major}.${version.Minor}.${version.Patch} ${this.userAgentSuffix}-${agentVersion}-${taskManifest.name}`
-            // tslint:disable-next-line:whitespace align
+        // tslint:disable-next-line:whitespace align
         ;((AWS as any).util as any).userAgent = () => {
             return userAgentString
         }


### PR DESCRIPTION
The user agent now looks like:
```
AWS-VSTS/1.7.4 exec-env/VSTS-2.144.2-S3Download
```
## License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
