### PR TITLE
Aligning aws.rolecredential.maxduration with STS max

### DIFF
--- a/.changes/next-release/Feature-cd3c151b-a3ed-4d11-803f-d99c26dedaaa.json
+++ b/.changes/next-release/Feature-cd3c151b-a3ed-4d11-803f-d99c26dedaaa.json
@@ -1,4 +1,4 @@
 {
     "type": "Feature",
-    "description": "Aligning aws.rolecredential.maxduration with STS max"
+    "description": "Update aws.rolecredential.maxduration to the STS max of 12 hours"
 }

--- a/.changes/next-release/Feature-cd3c151b-a3ed-4d11-803f-d99c26dedaaa.json
+++ b/.changes/next-release/Feature-cd3c151b-a3ed-4d11-803f-d99c26dedaaa.json
@@ -1,0 +1,4 @@
+{
+    "type": "Feature",
+    "description": "Aligning aws.rolecredential.maxduration with STS max"
+}

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Select the _AWS_ endpoint type and provide the following parameters. Please refe
 
 **Note** We strongly suggest you use access and secret keys generated for an Identity and Access Management (IAM) user account. You can configure an IAM user account with permissions granting access to only the services and resources required to support the tasks you intend to use in your build and release definitions.
 
-Tasks can also use assumed role credentials by adding the Amazon Resource name (ARN) of the role to be assumed and an optional identifier when configuring the endpoint. The access and secret keys specified will then be used to generate temporary credentials for the tasks when they are executed by the build agents. Temporary credentials are valid for up to 15 minutes by default. To enable a longer validity period you can set the 'aws.rolecredential.maxduration' variable on your build or release definition, specifying a validity period in seconds between 15 minutes (900 seconds) and one hour (3600 seconds).
+Tasks can also use assumed role credentials by adding the Amazon Resource name (ARN) of the role to be assumed and an optional identifier when configuring the endpoint. The access and secret keys specified will then be used to generate temporary credentials for the tasks when they are executed by the build agents. Temporary credentials are valid for up to 15 minutes by default. To enable a longer validity period you can set the 'aws.rolecredential.maxduration' variable on your build or release definition, specifying a validity period in seconds between 15 minutes (900 seconds) and 12 hours (43200 seconds).
 
 ## Supported environments
 

--- a/Tasks/Common/awsConnectionParameters.ts
+++ b/Tasks/Common/awsConnectionParameters.ts
@@ -29,9 +29,9 @@ export const awsRegionVariable: string = 'AWS.Region'
 export const defaultRoleSessionName: string = 'aws-vsts-tools'
 // The minimum duration, 15mins, should be enough for a task
 export const minDuration: number = 900
-export const maxduration: number = 3600
+export const maxduration: number = 43200
 // To have a longer duration, users can set this variable in their build or
-// release definitions to the required duration (in seconds, min 900 max 3600).
+// release definitions to the required duration (in seconds, min 900 max 43200).
 export const roleCredentialMaxDurationVariableName: string = 'aws.rolecredential.maxduration'
 
 export interface AWSConnectionParameters {

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -202,7 +202,7 @@
                             {
                                 "id": "assumeRoleArn",
                                 "name": "Role to Assume",
-                                "description": "The Amazon Resource Name (ARN) of the role to assume.\nIf a role ARN is specified the access and secret keys configured in the endpoint will be used to generate temporary session credentials, scoped to the specified role, and used be used by the task.\nThe generated credentials for each AWS task will be valid for a default duration of 15 minutes. If your tasks need a longer duration (up to a maximum of one hour) set the variable 'aws.rolecredential.maxduration' on your build or release definition to the required duration (in seconds, minimum 900 and maximum 3600). Note that this setting will affect all tasks that use AWS endpoints configured to assume a role.",
+                                "description": "The Amazon Resource Name (ARN) of the role to assume.\nIf a role ARN is specified the access and secret keys configured in the endpoint will be used to generate temporary session credentials, scoped to the specified role, and used be used by the task.\nThe generated credentials for each AWS task will be valid for a default duration of 15 minutes. If your tasks need a longer duration (up to a maximum of one hour) set the variable 'aws.rolecredential.maxduration' on your build or release definition to the required duration (in seconds, minimum 900 and maximum 43200). Note that this setting will affect all tasks that use AWS endpoints configured to assume a role.",
                                 "inputMode": "textbox",
                                 "isConfidential": false,
                                 "validation": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

AWS STS [allows the session duration ](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html)of an "assume-role" action to be 12 hours. 

However, we're limiting maxduration in this plugin to 1 hour, and I'm not sure what the reason is/was behind this.



## Motivation

Some of our pipelines need the session duration to be longer than an hour to allow our jobs to finish. Some of the examples are:
- Large terraform/infrastructure module with wait times involved.
- Running scripts that cycle out instances after gracefully draining them (K8S).

## Testing

I wouldn't know how to test this locally.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have read the **README** document
-   [x] I have read the **CONTRIBUTING** document
-   [x] My code follows the code style of this project
-   [ ] I have added tests to cover my changes
-   [x] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
