### PR TITLE
Fix vss-extension to support proper min of TFS 2017.1

### DIFF
--- a/vss-extension.json
+++ b/vss-extension.json
@@ -20,7 +20,11 @@
     },
     "targets": [
         {
-            "id": "Microsoft.VisualStudio.Services"
+            "id": "Microsoft.VisualStudio.Services.Cloud"
+        },
+        {
+            "id": "Microsoft.TeamFoundation.Server",
+            "version": "[15.1,)"
         }
     ],
     "tags": [


### PR DESCRIPTION
Based on https://docs.microsoft.com/en-us/azure/devops/extend/develop/manifest?view=azure-devops#installation-targets "Microsoft.VisualStudio.Services" actually targets the wrong thing, the min is too low. So, fix the min based on the examples on the page.
## License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
