### PR TITLE
Add .wasm MIME type for WebAssembly

### DIFF
--- a/src/lib/s3.ts
+++ b/src/lib/s3.ts
@@ -160,6 +160,7 @@ export const knownMimeTypes: Map<string, string> = new Map<string, string>([
     ['.vcd', 'application/x-cdlink'],
     ['.vda', 'application/vda'],
     ['.vrml', 'model/vrml'],
+    ['.wasm', 'application/wasm'],
     ['.wav', 'audio/x-wav'],
     ['.wrl', 'model/vrml'],
     ['.xbm', 'image/x-xbitmap'],


### PR DESCRIPTION
## Motivation

Required for compileStreaming and avoiding error logged to DevTools
https://webassembly.org/docs/web/

## Testing

Manually setting the MIME type on .wasm files in the bucket removes the error about incorrect MIME type.

## Checklist

-   [x] I have read the **README** document
-   [x] I have read the **CONTRIBUTING** document
-   [ ] My code follows the code style of this project
-   [ ] I have added tests to cover my changes
-   [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
