### PR TITLE
Add support for CloudWatch output config in SSM RunCommand task

### DIFF
--- a/.changes/next-release/Feature-2e4545c5-a2ab-4416-a8bc-9327daeccdcc.json
+++ b/.changes/next-release/Feature-2e4545c5-a2ab-4416-a8bc-9327daeccdcc.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Add support for CloudWatch output config in SSM RunCommand task"
+}

--- a/src/tasks/SystemsManagerRunCommand/TaskOperations.ts
+++ b/src/tasks/SystemsManagerRunCommand/TaskOperations.ts
@@ -38,6 +38,15 @@ export class TaskOperations {
         if (this.taskParameters.documentParameters) {
             request.Parameters = JSON.parse(this.taskParameters.documentParameters)
         }
+        if (this.taskParameters.cloudWatchOutputEnabled) {
+            request.CloudWatchOutputConfig = {
+                CloudWatchOutputEnabled: true
+            }
+
+            if (this.taskParameters.cloudWatchLogGroupName) {
+                request.CloudWatchOutputConfig.CloudWatchLogGroupName = this.taskParameters.cloudWatchLogGroupName
+            }
+        }
 
         switch (this.taskParameters.instanceSelector) {
             case fromInstanceIds:

--- a/src/tasks/SystemsManagerRunCommand/TaskParameters.ts
+++ b/src/tasks/SystemsManagerRunCommand/TaskParameters.ts
@@ -29,6 +29,8 @@ export interface TaskParameters {
     notificationType: string | undefined
     outputS3BucketName: string
     outputS3KeyPrefix: string
+    cloudWatchOutputEnabled: boolean;
+    cloudWatchLogGroupName: string;
     commandIdOutputVariable: string
 }
 
@@ -48,6 +50,8 @@ export function buildTaskParameters(): TaskParameters {
         notificationType: getInputOptional('notificationType'),
         outputS3BucketName: getInputOrEmpty('outputS3BucketName'),
         outputS3KeyPrefix: getInputOrEmpty('outputS3KeyPrefix'),
+        cloudWatchOutputEnabled: tl.getBoolInput('cloudWatchOutputEnabled'),
+        cloudWatchLogGroupName: getInputOrEmpty('cloudWatchLogGroupName'),
         commandIdOutputVariable: getInputOrEmpty('commandIdOutputVariable'),
         instanceIds: [],
         instanceTags: [],

--- a/src/tasks/SystemsManagerRunCommand/task.json
+++ b/src/tasks/SystemsManagerRunCommand/task.json
@@ -27,6 +27,11 @@
             "isExpanded": false
         },
         {
+            "name": "cloudWatchOutput",
+            "displayName": "Cloud Watch Options",
+            "isExpanded": false
+        },
+        {
             "name": "diagnostic",
             "displayName": "Diagnostic",
             "isExpanded": false
@@ -226,6 +231,24 @@
             "groupName": "output",
             "helpMarkDown": "The name of a variable that will contain the unique ID assigned to the command. The command ID can be used future references to the request.",
             "required": false
+        },
+        {
+            "name": "cloudWatchOutputEnabled",
+            "label": "Enable CloudWatch Logs",
+            "type": "boolean",
+            "required": false,
+            "defaultValue": false,
+            "groupName": "cloudWatchOutput",
+            "helpMarkDown": "Enables Systems Manager to send command output to CloudWatch Logs."
+        },
+        {
+            "name": "cloudWatchLogGroupName",
+            "label": "CloudWatch Log Group Name",
+            "type": "string",
+            "required": false,
+            "defaultValue": "",
+            "groupName": "cloudWatchOutput",
+            "helpMarkDown": "The name of the CloudWatch log group where you want to send command output. If you don’t specify a group name, Systems Manager automatically creates a log group for you. The log group uses the following naming format: <em>aws/ssm/SystemsManagerDocumentName</em> ."
         },
         {
             "name": "logRequest",

--- a/src/tasks/SystemsManagerRunCommand/task.json
+++ b/src/tasks/SystemsManagerRunCommand/task.json
@@ -28,7 +28,7 @@
         },
         {
             "name": "cloudWatchOutput",
-            "displayName": "Cloud Watch Options",
+            "displayName": "CloudWatch Options",
             "isExpanded": false
         },
         {
@@ -248,7 +248,8 @@
             "required": false,
             "defaultValue": "",
             "groupName": "cloudWatchOutput",
-            "helpMarkDown": "The name of the CloudWatch log group where you want to send command output. If you don’t specify a group name, Systems Manager automatically creates a log group for you. The log group uses the following naming format: <em>aws/ssm/SystemsManagerDocumentName</em> ."
+            "visibleRule": "cloudWatchOutputEnabled = true",
+            "helpMarkDown": "The name of the CloudWatch log group where you want to send command output. If you don’t specify a group name, Systems Manager automatically creates a log group for you. The log group uses the following naming format: <em>aws/ssm/<systems_manager_document_name></em>."
         },
         {
             "name": "logRequest",

--- a/tests/taskTests/systemsManagerRunCommand/systemsManagerRunCommand-test.ts
+++ b/tests/taskTests/systemsManagerRunCommand/systemsManagerRunCommand-test.ts
@@ -36,7 +36,7 @@ const defaultTaskParameters: TaskParameters = {
     outputS3KeyPrefix: '',
     cloudWatchOutputEnabled: false,
     cloudWatchLogGroupName: '',
-    commandIdOutputVariable: '',
+    commandIdOutputVariable: ''
 }
 
 const systemsManagerFails = {
@@ -138,7 +138,7 @@ describe('Systems Manager Run Command', () => {
         expect.assertions(2)
         const ssm = new SSM() as any
         ssm.sendCommand = jest.fn(args => {
-            expect(args.CloudWatchOutputConfig.CloudWatchLogGroupName).toBe('ssm')
+            expect(args.CloudWatchOutputConfig.CloudWatchLogGroupName).toBe('cloudWatchLogGroupName')
 
             return systemsManagerFails
         })
@@ -155,7 +155,7 @@ describe('Systems Manager Run Command', () => {
         expect.assertions(2)
         const ssm = new SSM() as any
         ssm.sendCommand = jest.fn(args => {
-            expect(args.CloudWatchOutputConfig).toBeNull()
+            expect(args.CloudWatchOutputConfig).toBeFalsy()
 
             return systemsManagerFails
         })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Add Cloud Wathc Output option groups, which supports CloudWatchOutputEnabled and CloudWatchLogGroupName in SSM RunCommand task.
![Screenshot from 2021-06-22 12-03-32](https://user-images.githubusercontent.com/11418231/122870864-6b8e4200-d358-11eb-8a02-125274268517.png)

## Motivation
<!--- Why is this change required? What problem does it solve? -->
- Allow sending SSM RunCommand logs to Cloud Watch. There's no such option at the moment, while AWS CLI Task could not parse JSON input required for `aws ssm send-command` properly, so adding an option for SSM RunCommand task makes most sense. 
 
## Related Issue(s), If Filed

<!--- What is the related issue you are trying to fix? -->
Fix #419 

## Testing

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Added unit tests for `ssmRunCommand`. This PR this add more parameters so no other code areas are impacted
- I published the extension to my own organization, tested with in my AWS Account successfully. You can see there's a CloudWatch Logs hyperlink in the Command Output below.
-
![Screenshot from 2021-06-22 12-15-11](https://user-images.githubusercontent.com/11418231/122871491-4d751180-d359-11eb-9fd6-b69c9f673a18.png)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [X] I have read the **README** document
-   [X] I have read the **CONTRIBUTING** document
-   [X] My code follows the code style of this project
-   [X] I have added tests to cover my changes
-   [X] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
