### PR TITLE
Wait for Lambda status change on create/update calls

### DIFF
--- a/.changes/next-release/Feature-d8cbf88e-be98-44d1-860e-fcd0366292f1.json
+++ b/.changes/next-release/Feature-d8cbf88e-be98-44d1-860e-fcd0366292f1.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Lambda create and update tasks utilize Lambda function states to signal completion"
+}

--- a/src/tasks/LambdaDeployFunction/TaskOperations.ts
+++ b/src/tasks/LambdaDeployFunction/TaskOperations.ts
@@ -10,6 +10,9 @@ import { SdkUtils } from 'lib/sdkutils'
 import { readFileSync } from 'fs'
 import { deployCodeAndConfig, deployCodeOnly, TaskParameters, updateFromLocalFile } from './TaskParameters'
 
+const FUNCTION_UPDATED = 'functionUpdated'
+const FUNCTION_ACTIVE = 'functionActive'
+
 export class TaskOperations {
     public constructor(
         public readonly iamClient: IAM,
@@ -66,10 +69,15 @@ export class TaskOperations {
             }
 
             const response = await this.lambdaClient.updateFunctionCode(updateCodeRequest).promise()
-
             if (!response.FunctionArn) {
                 throw new Error(tl.loc('NoFunctionArnReturned'))
             }
+
+            console.log(tl.loc('AwaitingStatus', this.taskParameters.functionName, FUNCTION_UPDATED))
+            await this.lambdaClient
+                .waitFor(FUNCTION_UPDATED, { FunctionName: this.taskParameters.functionName })
+                .promise()
+            console.log(tl.loc('AwaitingStatusComplete', this.taskParameters.functionName, FUNCTION_UPDATED))
 
             return response.FunctionArn
         } catch (err) {
@@ -123,6 +131,12 @@ export class TaskOperations {
             if (!response.FunctionArn) {
                 throw new Error(tl.loc('NoFunctionArnReturned'))
             }
+
+            console.log(tl.loc('AwaitingStatus', this.taskParameters.functionName, FUNCTION_UPDATED))
+            await this.lambdaClient
+                .waitFor(FUNCTION_UPDATED, { FunctionName: this.taskParameters.functionName })
+                .promise()
+            console.log(tl.loc('AwaitingStatusComplete', this.taskParameters.functionName, FUNCTION_UPDATED))
 
             // Update tags if we have them
             const tags = SdkUtils.getTagsDictonary<Lambda.Tags>(this.taskParameters.tags)
@@ -203,6 +217,12 @@ export class TaskOperations {
                 throw new Error(tl.loc('NoFunctionArnReturned'))
             }
 
+            console.log(tl.loc('AwaitingStatus', this.taskParameters.functionName, FUNCTION_ACTIVE))
+            await this.lambdaClient
+                .waitFor(FUNCTION_ACTIVE, { FunctionName: this.taskParameters.functionName })
+                .promise()
+            console.log(tl.loc('AwaitingStatusComplete', this.taskParameters.functionName, FUNCTION_ACTIVE))
+
             return response.FunctionArn
         } catch (err) {
             throw new Error(`Failed to create function, error ${err}`)
@@ -211,7 +231,7 @@ export class TaskOperations {
 
     private async testFunctionExists(functionName: string): Promise<boolean> {
         try {
-            const response = await this.lambdaClient
+            await this.lambdaClient
                 .getFunction({
                     FunctionName: functionName
                 })

--- a/src/tasks/LambdaDeployFunction/TaskOperations.ts
+++ b/src/tasks/LambdaDeployFunction/TaskOperations.ts
@@ -73,11 +73,7 @@ export class TaskOperations {
                 throw new Error(tl.loc('NoFunctionArnReturned'))
             }
 
-            console.log(tl.loc('AwaitingStatus', this.taskParameters.functionName, FUNCTION_UPDATED))
-            await this.lambdaClient
-                .waitFor(FUNCTION_UPDATED, { FunctionName: this.taskParameters.functionName })
-                .promise()
-            console.log(tl.loc('AwaitingStatusComplete', this.taskParameters.functionName, FUNCTION_UPDATED))
+            await this.waitForUpdate()
 
             return response.FunctionArn
         } catch (err) {
@@ -132,11 +128,7 @@ export class TaskOperations {
                 throw new Error(tl.loc('NoFunctionArnReturned'))
             }
 
-            console.log(tl.loc('AwaitingStatus', this.taskParameters.functionName, FUNCTION_UPDATED))
-            await this.lambdaClient
-                .waitFor(FUNCTION_UPDATED, { FunctionName: this.taskParameters.functionName })
-                .promise()
-            console.log(tl.loc('AwaitingStatusComplete', this.taskParameters.functionName, FUNCTION_UPDATED))
+            await this.waitForUpdate()
 
             // Update tags if we have them
             const tags = SdkUtils.getTagsDictonary<Lambda.Tags>(this.taskParameters.tags)
@@ -241,5 +233,11 @@ export class TaskOperations {
         } catch (err) {
             return false
         }
+    }
+
+    private async waitForUpdate(): Promise<void> {
+        console.log(tl.loc('AwaitingStatus', this.taskParameters.functionName, FUNCTION_UPDATED))
+        await this.lambdaClient.waitFor(FUNCTION_UPDATED, { FunctionName: this.taskParameters.functionName }).promise()
+        console.log(tl.loc('AwaitingStatusComplete', this.taskParameters.functionName, FUNCTION_UPDATED))
     }
 }

--- a/src/tasks/LambdaDeployFunction/task.json
+++ b/src/tasks/LambdaDeployFunction/task.json
@@ -315,6 +315,9 @@
         "FunctionNotFound": "Function %s does not exist, cannot update code only",
         "TaskCompleted": "Completed create or update of Lambda function %s, function ARN %s",
         "AddingTag": "Adding tag. Key '%s', Value '%s'",
-        "NoFunctionArnReturned": "No function ARN returned from the service! Deployment failed!"
+        "NoFunctionArnReturned": "No function ARN returned from the service! Deployment failed!",
+        "SettingOutputVariable": "Setting output variable %s with the function output",
+        "AwaitingStatus": "Waiting for function %s to reach %s state...",
+        "AwaitingStatusComplete": "Function %s has reached %s state"
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Wait for Lambda status changes after creating and on update* calls.

## Motivation

https://aws.amazon.com/blogs/compute/coming-soon-expansion-of-aws-lambda-states-to-all-functions/

## Testing
Tests testing failures pass successfully. Manual tests (All successes) have passed. Unfortunately, cannot force Lambda to take >20 seconds to update state reliably so cannot test failure case.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have read the **README** document
-   [x] I have read the **CONTRIBUTING** document
-   [x] My code follows the code style of this project
-   [x] I have added tests to cover my changes
-   [x] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
