### PR TITLE
Lambda Create/Update handles lack of GetFunctionConfiguration

### DIFF
--- a/.changes/next-release/Feature-efef33cb-2f0d-495a-999b-4b3448351410.json
+++ b/.changes/next-release/Feature-efef33cb-2f0d-495a-999b-4b3448351410.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Lambda Deploy Function gracefully handles missing lambda:GetFunctionConfiguration with a warning and a 5-second wait"
+}

--- a/src/tasks/LambdaDeployFunction/task.json
+++ b/src/tasks/LambdaDeployFunction/task.json
@@ -4,7 +4,7 @@
     "friendlyName": "AWS Lambda Deploy Function",
     "description": "General purpose deployment of AWS Lambda functions for all supported language runtimes.",
     "author": "Amazon Web Services",
-    "helpMarkDown": "Please refer to [AWS Lambda Developer Guide](https://docs.aws.amazon.com/lambda/latest/dg/) for more information on working with AWS Lambda.\n\nMore information on this task can be found in the [task reference](https://docs.aws.amazon.com/vsts/latest/userguide/lambda-deploy.html).\n\n####Task Permissions\nThis task requires permissions to call the following AWS service APIs (depending on selected task options, not all APIs may be used):\n* lambda:CreateFunction\n* lambda:GetFunction\n* lambda:UpdateFunctionCode\n* lambda:UpdateFunctionConfiguration",
+    "helpMarkDown": "Please refer to [AWS Lambda Developer Guide](https://docs.aws.amazon.com/lambda/latest/dg/) for more information on working with AWS Lambda.\n\nMore information on this task can be found in the [task reference](https://docs.aws.amazon.com/vsts/latest/userguide/lambda-deploy.html).\n\n####Task Permissions\nThis task requires permissions to call the following AWS service APIs (depending on selected task options, not all APIs may be used):\n* lambda:CreateFunction\n* lambda:GetFunction\n* lambda:GetFunctionConfiguration\n* lambda:UpdateFunctionCode\n* lambda:UpdateFunctionConfiguration",
     "category": "Deploy",
     "visibility": ["Build", "Release"],
     "demands": [],
@@ -318,6 +318,7 @@
         "NoFunctionArnReturned": "No function ARN returned from the service! Deployment failed!",
         "SettingOutputVariable": "Setting output variable %s with the function output",
         "AwaitingStatus": "Waiting for function %s to reach %s state...",
-        "AwaitingStatusComplete": "Function %s has reached %s state"
+        "AwaitingStatusComplete": "Function %s has reached %s state",
+        "CantWaitWarning": "Role doesn't have Lambda States waiting permissions; will wait %s seconds and proceed. To avoid this in the future, grant %s permissions to the task role!"
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Users without `lambda.GetFunctionConfiguration` permissions will get warned and have a 5 second wait inserted into their **AWS Lambda Deploy Function** workflows.

## Motivation

The last release included changes for Lambda States handling but did not include the reliance on `GetFunctionConfiguration`. This handles the omission gracefully and provides users with enough information to update their workflow to 1: make it faster and 2: fix issues in case their Lambda takes > 5 seconds to get ready.

## Related Issue(s), If Filed

https://github.com/aws/aws-toolkit-azure-devops/issues/445

## Testing

Tested with multiple combinations of IAM permissions. Correctly waits for 5 seconds when `GetFunctionConfiguration` permissions aren't present

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have read the **README** document
-   [x] I have read the **CONTRIBUTING** document
-   [x] My code follows the code style of this project
-   [x] I have added tests to cover my changes
-   [x] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
