### PR TITLE
from PS version 3 and beyond import-module is not required, this also…

### DIFF
--- a/src/tasks/AWSPowerShellModuleScript/RunAWSPowerShellModuleScript.ps1
+++ b/src/tasks/AWSPowerShellModuleScript/RunAWSPowerShellModuleScript.ps1
@@ -57,8 +57,6 @@ try {
         }
     }
 
-    Import-Module -Name AWSPowerShell
-
     ###############################################################################
     # If credentials and/or region are not defined on the task we assume them to be
     # already set in the host environment or, if on EC2, to be in instance metadata.


### PR DESCRIPTION
… slows performance

I have removed Import-module from AWSPowerShellModuleScript as it slows task performance and isnt needed in ps version > 3 (https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/import-module?view=powershell-7.2#description)

## Description

Removed "Import-Module -Name AWSPowerShell"

## Motivation

AWSPowerShellModuleScript@1 was performing slowly for no reason

## Related Issue(s), If Filed

slow performance

## Testing

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have read the **README** document
-   [x] I have read the **CONTRIBUTING** document
-   [x] My code follows the code style of this project
-   [ ] I have added tests to cover my changes
-   [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
