### PR TITLE
chore: replace deprecated String.prototype.substr()

### DIFF
--- a/src/tasks/S3Upload/TaskOperations.ts
+++ b/src/tasks/S3Upload/TaskOperations.ts
@@ -148,7 +148,7 @@ export class TaskOperations {
         for (const matchedFile of matchedFiles) {
             let relativePath = matchedFile.substring(this.taskParameters.sourceFolder.length)
             if (relativePath.startsWith(path.sep)) {
-                relativePath = relativePath.substr(1)
+                relativePath = relativePath.slice(1)
             }
             let targetPath = relativePath
 


### PR DESCRIPTION
## Description

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

## Motivation

<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s), If Filed

<!--- What is the related issue you are trying to fix? -->

## Testing

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have read the **README** document
-   [x] I have read the **CONTRIBUTING** document
-   [x] My code follows the code style of this project
-   [ ] I have added tests to cover my changes
-   [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
