### PR TITLE
Add ACL support to CodeDeploy task

### DIFF
--- a/.changes/next-release/Feature-3dfa1544-2757-4457-97ad-0a91767a833f.json
+++ b/.changes/next-release/Feature-3dfa1544-2757-4457-97ad-0a91767a833f.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Added \"filesAcl\" parameter to CodeDeploy task when uploading to S3"
+}

--- a/src/tasks/CodeDeployDeployApplication/TaskOperations.ts
+++ b/src/tasks/CodeDeployDeployApplication/TaskOperations.ts
@@ -122,13 +122,17 @@ export class TaskOperations {
         console.log(tl.loc('UploadingBundle', archiveName, key, this.taskParameters.bucketName))
         const fileBuffer = fs.createReadStream(archiveName)
         try {
-            const response: S3.ManagedUpload.SendData = await this.s3Client
-                .upload({
-                    Bucket: this.taskParameters.bucketName,
-                    Key: key,
-                    Body: fileBuffer
-                })
-                .promise()
+            const request: S3.PutObjectRequest = {
+                Bucket: this.taskParameters.bucketName,
+                Key: key,
+                Body: fileBuffer
+            }
+
+            if (this.taskParameters.filesAcl && this.taskParameters.filesAcl !== 'none') {
+                request.ACL = this.taskParameters.filesAcl
+            }
+
+            await this.s3Client.upload(request).promise()
             console.log(tl.loc('BundleUploadCompleted'))
 
             // clean up the archive if we created one

--- a/src/tasks/CodeDeployDeployApplication/TaskParameters.ts
+++ b/src/tasks/CodeDeployDeployApplication/TaskParameters.ts
@@ -20,6 +20,7 @@ export interface TaskParameters {
     bucketName: string
     bundlePrefix: string
     bundleKey: string
+    filesAcl: string
     description: string
     fileExistsBehavior: string | undefined
     updateOutdatedInstancesOnly: boolean
@@ -38,6 +39,7 @@ export function buildTaskParameters(): TaskParameters {
         bucketName: getInputRequired('bucketName'),
         bundlePrefix: '',
         bundleKey: '',
+        filesAcl: '',
         description: getInputOrEmpty('description'),
         fileExistsBehavior: tl.getInput('fileExistsBehavior', false),
         updateOutdatedInstancesOnly: tl.getBoolInput('updateOutdatedInstancesOnly', false),
@@ -50,6 +52,7 @@ export function buildTaskParameters(): TaskParameters {
         case revisionSourceFromWorkspace:
             parameters.revisionBundle = getPathInputRequiredCheck('revisionBundle')
             parameters.bundlePrefix = getInputOrEmpty('bundlePrefix')
+            parameters.filesAcl = getInputOrEmpty('filesAcl')
             break
 
         case revisionSourceFromS3:

--- a/src/tasks/CodeDeployDeployApplication/task.json
+++ b/src/tasks/CodeDeployDeployApplication/task.json
@@ -112,6 +112,25 @@
             "helpMarkDown": "The Amazon S3 object key of the previously uploaded archive file containing the deployment revision artifacts."
         },
         {
+            "name": "filesAcl",
+            "type": "pickList",
+            "label": "Access Control (ACL)",
+            "defaultValue": "none",
+            "required": false,
+            "visibleRule": "deploymentRevisionSource = workspace",
+            "helpMarkDown": "The canned Access Control List (ACL) to apply to the uploaded content. See [Canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) for an explanation of the possible values. By default, no ACL is applied.",
+            "options": {
+                "none": "none",
+                "private": "private",
+                "public-read": "public read",
+                "public-read-write": "public read write",
+                "authenticated-read": "authenticated read",
+                "aws-exec-read": "aws-exec-read",
+                "bucket-owner-read": "bucket-owner-read",
+                "bucket-owner-full-control": "bucket-owner-full-control"
+            }
+        },
+        {
             "name": "description",
             "label": "Description",
             "type": "string",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds an optional "filesAcl" parameter to the CodeDeploy task when uploading content from the workspace.
By default, previous behavior is preserved (no ACL parameter is passed).
This makes the parameter slightly diverge from the S3Upload task where 'private' is the default, though I think it's necessary for backwards compatibility.

## Motivation

See https://github.com/aws/aws-toolkit-azure-devops/issues/368

## Related Issue(s), If Filed

<!--- What is the related issue you are trying to fix? -->

## Testing

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manual + unit tests

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have read the **README** document
-   [x] I have read the **CONTRIBUTING** document
-   [x] My code follows the code style of this project
-   [x] I have added tests to cover my changes
-   [x] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
