### PR TITLE
Add an option to clean up docker images after ECR push

### DIFF
--- a/.changes/next-release/Feature-3e7fa900-c9c0-4a29-8b6a-c32d241fa66c.json
+++ b/.changes/next-release/Feature-3e7fa900-c9c0-4a29-8b6a-c32d241fa66c.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Add an option to remove docker image after an ECR push"
+}

--- a/src/tasks/ECRPushImage/TaskOperations.ts
+++ b/src/tasks/ECRPushImage/TaskOperations.ts
@@ -83,6 +83,10 @@ export class TaskOperations {
             tl.setVariable(this.taskParameters.outputVariable, targetImageRef)
         }
 
+        if (this.taskParameters.removeDockerImage) {
+            await this.removeDockerImage(sourceImageRef)
+        }
+
         console.log(tl.loc('TaskCompleted'))
     }
 
@@ -117,5 +121,10 @@ export class TaskOperations {
     private async pushImageToECR(imageRef: string): Promise<void> {
         console.log(tl.loc('PushingImage', imageRef))
         await this.dockerHandler.runDockerCommand(this.dockerPath, 'push', [imageRef])
+    }
+
+    private async removeDockerImage(imageRef: string): Promise<void> {
+        console.log(tl.loc('RemovingImage', imageRef))
+        await this.dockerHandler.runDockerCommand(this.dockerPath, 'rmi', [imageRef], '-f')
     }
 }

--- a/src/tasks/ECRPushImage/TaskParameters.ts
+++ b/src/tasks/ECRPushImage/TaskParameters.ts
@@ -20,6 +20,7 @@ export interface TaskParameters {
     pushTag: string
     autoCreateRepository: boolean
     forceDockerNamingConventions: boolean
+    removeDockerImage: boolean
     outputVariable: string
 }
 
@@ -31,6 +32,7 @@ export function buildTaskParameters(): TaskParameters {
         pushTag: getInputOrEmpty('pushTag'),
         autoCreateRepository: tl.getBoolInput('autoCreateRepository', false),
         forceDockerNamingConventions: tl.getBoolInput('forceDockerNamingConventions', false),
+        removeDockerImage: tl.getBoolInput('removeDockerImage', false),
         outputVariable: getInputOrEmpty('outputVariable'),
         sourceImageName: '',
         sourceImageId: '',

--- a/src/tasks/ECRPushImage/task.json
+++ b/src/tasks/ECRPushImage/task.json
@@ -55,7 +55,7 @@
                 "imageid": "Image ID"
             },
             "properties": {
-                "EditableOptions": "false"
+                "EditableOptions": "False"
             }
         },
         {
@@ -118,6 +118,14 @@
             "helpMarkDown": "If enabled, the Docker repository name will be modified to follow Docker naming conventions. Converts upper case characters to lower case. Removes all characters except 0-9, -, . and _ ."
         },
         {
+            "name": "removeDockerImage",
+            "label": "Remove Docker image after ECR push",
+            "type": "boolean",
+            "defaultValue": false,
+            "required": false,
+            "helpMarkDown": "If enabled, this command removes the image and untags any references to it"
+        },
+        {
             "name": "outputVariable",
             "type": "string",
             "label": "Image Tag Output Variable",
@@ -157,6 +165,7 @@
         "RequestingAuthToken": "Obtaining authentication token for ECR login",
         "AddingTag": "Adding tag '%s' to image '%s'",
         "PushingImage": "Pushing image '%s' to Elastic Container Registry",
+        "RemovingImage": "Removing image '%s' and untagging any references to the image",
         "InvokingDockerCommand": "Invoking '%s' with command '%s'",
         "TestingForRepository": "Testing existence of repository '%s'",
         "CreatingRepository": "Repository not found, attempting to create",

--- a/src/tasks/SystemsManagerGetParameter/task.json
+++ b/src/tasks/SystemsManagerGetParameter/task.json
@@ -192,7 +192,7 @@
         "UsingParameterNameForVariable": "Using original parameter name %s for build variable",
         "TaskCompleted": "Successfully created variables from parameter value(s).",
         "InvalidParameterVersion": "%s is not a valid parameter version number. Version numbers should be >= 1",
-        "UnknownReadMode": "%s is not a valid paramater for ReadMode. Paramater must be one of \"single\" or \"hierarchy\"",
+        "UnknownReadMode": "%s is not a valid parameter for ReadMode. Parameter must be one of \"single\" or \"hierarchy\"",
         "ErrorParametersEmpty": "Response did not have any parameters attached!"
     }
 }

--- a/tests/taskTests/ecrPushImage/ecrPushImage-test.ts
+++ b/tests/taskTests/ecrPushImage/ecrPushImage-test.ts
@@ -92,8 +92,7 @@ describe('ECR Push image', () => {
         const dockerHandler = { ...defaultDocker }
         const runDockerCommand = jest.fn(async (thing1, thing2, thing3, thing4) => undefined)
         dockerHandler.runDockerCommand = runDockerCommand
-        const taskParameters = { ...defaultTaskParameters }
-        taskParameters.removeDockerImage = true
+        const taskParameters = { ...defaultTaskParameters, removeDockerImage: true }
         const taskOperations = new TaskOperations(ecr, dockerHandler, taskParameters)
         await taskOperations.execute()
         expect(ecr.getAuthorizationToken).toBeCalledTimes(1)

--- a/tests/taskTests/ecrPushImage/ecrPushImage-test.ts
+++ b/tests/taskTests/ecrPushImage/ecrPushImage-test.ts
@@ -22,6 +22,7 @@ const defaultTaskParameters: TaskParameters = {
     pushTag: '',
     autoCreateRepository: false,
     forceDockerNamingConventions: false,
+    removeDockerImage: false,
     outputVariable: ''
 }
 
@@ -85,19 +86,22 @@ describe('ECR Push image', () => {
     })
 
     test('Runs docker commands', async () => {
-        expect.assertions(5)
+        expect.assertions(6)
         const ecr = new ECR() as any
         ecr.getAuthorizationToken = jest.fn(() => ecrReturnsToken)
         const dockerHandler = { ...defaultDocker }
-        const runDockerCommand = jest.fn(async (thing1, thing2, thing3) => undefined)
+        const runDockerCommand = jest.fn(async (thing1, thing2, thing3, thing4) => undefined)
         dockerHandler.runDockerCommand = runDockerCommand
-        const taskOperations = new TaskOperations(ecr, dockerHandler, defaultTaskParameters)
+        const taskParameters = { ...defaultTaskParameters }
+        taskParameters.removeDockerImage = true
+        const taskOperations = new TaskOperations(ecr, dockerHandler, taskParameters)
         await taskOperations.execute()
         expect(ecr.getAuthorizationToken).toBeCalledTimes(1)
-        expect(runDockerCommand).toBeCalledTimes(3)
+        expect(runDockerCommand).toBeCalledTimes(4)
         expect(runDockerCommand.mock.calls[0][1]).toBe('tag')
         expect(runDockerCommand.mock.calls[1][1]).toBe('login')
         expect(runDockerCommand.mock.calls[2][1]).toBe('push')
+        expect(runDockerCommand.mock.calls[3][1]).toBe('rmi')
     })
 
     test('autocreate creates repository', async () => {

--- a/tests/taskTests/systemsManagerGetParameter/systemsManagerGetParameter-test.ts
+++ b/tests/taskTests/systemsManagerGetParameter/systemsManagerGetParameter-test.ts
@@ -76,10 +76,10 @@ describe('Systems Manager Get Parameter', () => {
         expect(new TaskOperations(new SSM(), defaultTaskParameters)).not.toBeNull()
     })
 
-    test('Read mode unknown throws', () => {
+    test('Read mode unknown throws', async () => {
         expect.assertions(1)
         const taskOperations = new TaskOperations(new SSM(), defaultTaskParameters)
-        taskOperations.execute().catch(e => expect(e).toContain('is not a valid parameter'))
+        await taskOperations.execute().catch(e => expect(`${e}`).toContain('is not a valid parameter'))
     })
 
     test('Read mode single reads', async () => {


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Add an option to clean up docker images after ECR push. This command will remove the image and untag any references to it. 

![image](https://user-images.githubusercontent.com/87440654/160947031-10df2e2f-782b-458d-ad63-e8eab151f80f.png)

This change also fixes some typos and a broken test case. 


## Motivation
see #364

## Testing
Manual + unit test. 
Tested using Hosted server. 

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have read the **README** document
-   [x] I have read the **CONTRIBUTING** document
-   [x] My code follows the code style of this project
-   [x] I have added tests to cover my changes
-   [x] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
