### PR TITLE
Fix S3 download mkdirp folders instead of writeStream

### DIFF
--- a/.changes/next-release/Bug Fix-8563f281-45a1-430b-999f-9a70940dc983.json
+++ b/.changes/next-release/Bug Fix-8563f281-45a1-430b-999f-9a70940dc983.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "s3 download handle folders with mkdirp instead of stream writer"
+}

--- a/.changes/next-release/Bug Fix-8563f281-45a1-430b-999f-9a70940dc983.json
+++ b/.changes/next-release/Bug Fix-8563f281-45a1-430b-999f-9a70940dc983.json
@@ -1,4 +1,4 @@
 {
 	"type": "Bug Fix",
-	"description": "s3 download handle folders with mkdirp instead of stream writer"
+	"description": "S3Download now correctly handles directories"
 }


### PR DESCRIPTION
S3 download task mkdirp folders instead of writeStream

## Description

I added directory detection with slash ending, separated the directory keys creation to use mkdirp and preserved the current logic for files.

## Motivation

the S3 download task failed to create nested objects after creating base directories as 0 byte files.

## Related Issue(s), If Filed

#480 
#468 

## Testing

Manual tests only.

## Checklist

-   [x] I have read the **README** document
-   [x] I have read the **CONTRIBUTING** document
-   [x] My code follows the code style of this project
-   [ ] I have added tests to cover my changes
-   [x] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
