### PR TITLE
Fix timeout property for CloudFormation update

### DIFF
--- a/.changes/next-release/Bug Fix-e2964197-a8c9-48dd-a48d-3646010ba79c.json
+++ b/.changes/next-release/Bug Fix-e2964197-a8c9-48dd-a48d-3646010ba79c.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "fix timeout property for CloudFormation update"
+}

--- a/src/lib/cloudformationutils.ts
+++ b/src/lib/cloudformationutils.ts
@@ -64,10 +64,15 @@ export async function testStackHasResources(cloudFormationClient: CloudFormation
     }
 }
 
-export async function waitForStackUpdate(cloudFormationClient: CloudFormation, stackName: string): Promise<void> {
+export async function waitForStackUpdate(
+    cloudFormationClient: CloudFormation,
+    stackName: string,
+    timeoutInMins: number = defaultTimeoutInMins
+): Promise<void> {
     console.log(tl.loc('WaitingForStackUpdate', stackName))
     try {
-        await cloudFormationClient.waitFor('stackUpdateComplete', { StackName: stackName }).promise()
+        const parms: any = setWaiterParams(stackName, timeoutInMins)
+        await cloudFormationClient.waitFor('stackUpdateComplete', parms).promise()
         console.log(tl.loc('StackUpdated', stackName))
     } catch (err) {
         throw new Error(tl.loc('StackUpdateFailed', stackName, (err as Error).message))

--- a/src/lib/cloudformationutils.ts
+++ b/src/lib/cloudformationutils.ts
@@ -71,8 +71,8 @@ export async function waitForStackUpdate(
 ): Promise<void> {
     console.log(tl.loc('WaitingForStackUpdate', stackName))
     try {
-        const parms: any = setWaiterParams(stackName, timeoutInMins)
-        await cloudFormationClient.waitFor('stackUpdateComplete', parms).promise()
+        const params: any = setWaiterParams(stackName, timeoutInMins)
+        await cloudFormationClient.waitFor('stackUpdateComplete', params).promise()
         console.log(tl.loc('StackUpdated', stackName))
     } catch (err) {
         throw new Error(tl.loc('StackUpdateFailed', stackName, (err as Error).message))
@@ -86,8 +86,8 @@ export async function waitForStackCreation(
 ): Promise<void> {
     console.log(tl.loc('WaitingForStackCreation', stackName))
     try {
-        const parms: any = setWaiterParams(stackName, timeoutInMins)
-        await cloudFormationClient.waitFor('stackCreateComplete', parms).promise()
+        const params: any = setWaiterParams(stackName, timeoutInMins)
+        await cloudFormationClient.waitFor('stackCreateComplete', params).promise()
         console.log(tl.loc('StackCreated', stackName))
     } catch (err) {
         throw new Error(tl.loc('StackCreationFailed', stackName, err.message))

--- a/src/tasks/CloudFormationCreateOrUpdateStack/TaskOperations.ts
+++ b/src/tasks/CloudFormationCreateOrUpdateStack/TaskOperations.ts
@@ -225,7 +225,7 @@ export class TaskOperations {
 
         try {
             await this.cloudFormationClient.updateStack(request).promise()
-            await waitForStackUpdate(this.cloudFormationClient, request.StackName)
+            await waitForStackUpdate(this.cloudFormationClient, request.StackName, this.taskParameters.timeoutInMins)
         } catch (err) {
             const e = <AWSError>err
             if (isNoWorkToDoValidationError(e.code, e.message)) {
@@ -365,7 +365,7 @@ export class TaskOperations {
                 .promise()
 
             if (await testStackHasResources(this.cloudFormationClient, stackName)) {
-                await waitForStackUpdate(this.cloudFormationClient, stackName)
+                await waitForStackUpdate(this.cloudFormationClient, stackName, this.taskParameters.timeoutInMins)
             } else {
                 await waitForStackCreation(this.cloudFormationClient, stackName, this.taskParameters.timeoutInMins)
             }

--- a/src/tasks/CloudFormationCreateOrUpdateStack/TaskOperations.ts
+++ b/src/tasks/CloudFormationCreateOrUpdateStack/TaskOperations.ts
@@ -533,8 +533,8 @@ export class TaskOperations {
     private async waitForChangeSetCreation(changeSetName: string, stackName: string): Promise<boolean> {
         console.log(tl.loc('WaitingForChangeSetValidation', changeSetName, stackName))
         try {
-            const parms: any = setWaiterParams(stackName, this.taskParameters.timeoutInMins, changeSetName)
-            await this.cloudFormationClient.waitFor('changeSetCreateComplete', parms).promise()
+            const params: any = setWaiterParams(stackName, this.taskParameters.timeoutInMins, changeSetName)
+            await this.cloudFormationClient.waitFor('changeSetCreateComplete', params).promise()
             console.log(tl.loc('ChangeSetValidated'))
         } catch (err) {
             // Inspect to see if the error was down to the service reporting (as an exception trapped


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
add timeout property to cloudformation update
<!--- Describe your changes in detail -->
## Motivation
timeout property worked for cloudformation create, but was ignored for cloudformation updates

<!--- Why is this change required? What problem does it solve? -->

## Related Issue(s), If Filed
#374 

## License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
