### PR TITLE
Update isNoWorkToDoValidationError to widen scope of error messages included

### DIFF
--- a/src/lib/cloudformationutils.ts
+++ b/src/lib/cloudformationutils.ts
@@ -162,7 +162,7 @@ export async function testChangeSetExists(
 // a no-op.
 export function isNoWorkToDoValidationError(errCodeOrStatus?: string, errMessage?: string): boolean {
     const knownNoOpErrorMessages = [
-        /^No updates are to be performed./,
+        /No updates are to be performed./,
         /^The submitted information didn't contain changes./
     ]
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

There is a function that determines if an error occurred when processing a Cloudformation stack Create Or Update, it appears the at least one of the error messages returned by the AWS API have changed slightly and this update is to make a slight change to the known error messages validation to ensure that the updated error from AWS can be handled by this function.

The error message causing the issue is "CloudFormation failed to preprocess the stack: No updates are to be performed." the current code looks for errors starting with "No updates are to be performed." but it appears AWS has modified the error message to include the additional wording "CloudFormation failed to preprocess the stack: ".

## Motivation

This issue currently breaks Azure DevOps pipelines that use the aws-toolkit to perform Cloudformation stack updates where no changes are to be applied, this sometimes happens when a pipeline is re-run using the same Cloudformation template. It has been fixed a couple of times in the past and this is a new iteration on that. 

## Related Issue(s), If Filed

No related issues.

## Testing

Changes tested locally to verify the update works as expected.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x ] I have read the **README** document
-   [ x] I have read the **CONTRIBUTING** document
-   [ x] My code follows the code style of this project
-   [ ] I have added tests to cover my changes
-   [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
