### PR TITLE
Mark shelljs as external for esbuild bundling

### DIFF
--- a/build-scripts/packageExtension.ts
+++ b/build-scripts/packageExtension.ts
@@ -118,7 +118,8 @@ function packagePlugin(options: CommandLineOptions) {
                 platform: 'node',
                 target: ['node10'],
                 minify: true,
-                outfile: `${taskPackageFolder}/${taskName}.js`
+                outfile: `${taskPackageFolder}/${taskName}.js`,
+                external: ['shelljs'] // mitigates shelljs bundling issue -- https://github.com/microsoft/azure-pipelines-task-lib/issues/942
             })
             result.warnings.forEach(warning => console.log(warning))
         } catch (err) {


### PR DESCRIPTION
Marks ShellJS as external for ESBuild Bundling. This fixes the issue in #522 

## Description

This issue emerged with the bump of azure-pipelines-task-lib dependency in: https://github.com/aws/aws-toolkit-azure-devops/pull/473.

Problem summarized in the open issue on azure-pipelines-task-lib repo: [Cannot use JS bundler because of shelljs dependency](https://github.com/microsoft/azure-pipelines-task-lib/issues/942).

Essentially, the toolkit takes a dependency on azure-pipelines-task-lib which takes an additional dependency on ShellJS. Our toolkit uses the esbuild JS Bundler to build the extension. This fails to bundle ShellJS because it uses dynamic require statements ([problematic ShellJS code](https://github.com/shelljs/shelljs/blob/a6d1e49f180a495d83bcf67bd85782c626aae029/shell.js#L23-L26)) instead of explicit require statements, which prevents bundlers from correctly analyzing the dependencies.
-  In short, require('./a') works but require('./' + 'a') doesn't.

## Related Issue(s), If Filed
- An [issue](https://github.com/shelljs/shelljs/issues/962) and [PR](https://github.com/shelljs/shelljs/pull/1119) have been opened on the ShellJS repo to change these dynamic require statements to explicit, but there are no plans to accommodate this in ShellJS

## Testing

Confirmed that tasks run locally (e.g. `node ./package/Tasks/AWSCLI/AWSCLI.js`) and on hosted agent

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have read the **README** document
-   [x] I have read the **CONTRIBUTING** document
-   [x] My code follows the code style of this project
-   [ ] I have added tests to cover my changes
-   [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
