### PR TITLE
Fix ENOENT error on s3 upload readStream

### DIFF
--- a/tests/taskTests/codeDeployDeployApplication/codeDeployDeployApplication-test.ts
+++ b/tests/taskTests/codeDeployDeployApplication/codeDeployDeployApplication-test.ts
@@ -161,6 +161,7 @@ describe('CodeDeploy Deploy Application', () => {
                     }
                 }
 
+                // Allows sufficient time for readStream to finish reading the file before attempting file deletion
                 return sleepOneSecPromise
             })
 
@@ -176,6 +177,7 @@ describe('CodeDeploy Deploy Application', () => {
             s3.upload = jest.fn(args => {
                 expect(args.ACL).toBe('bucket-owner-full-control')
 
+                // Allows sufficient time for readStream to finish reading the file before attempting file deletion
                 return sleepOneSecPromise
             })
 
@@ -191,6 +193,7 @@ describe('CodeDeploy Deploy Application', () => {
             s3.upload = jest.fn(args => {
                 expect(args.ACL).toBeUndefined()
 
+                // Allows sufficient time for readStream to finish reading the file before attempting file deletion
                 return sleepOneSecPromise
             })
 

--- a/tests/taskTests/codeDeployDeployApplication/codeDeployDeployApplication-test.ts
+++ b/tests/taskTests/codeDeployDeployApplication/codeDeployDeployApplication-test.ts
@@ -5,7 +5,7 @@
 
 import { CodeDeploy, S3 } from 'aws-sdk'
 import { SdkUtils } from 'lib/sdkutils'
-import fs = require('fs')
+import fs = require('fs-extra')
 import path = require('path')
 import { TaskOperations } from 'tasks/CodeDeployDeployApplication/TaskOperations'
 import {
@@ -40,11 +40,19 @@ const emptyPromise = {
     promise: () => ({})
 }
 
+const sleepOneSecPromise = {
+    promise: async () => {
+        await new Promise(f => setTimeout(f, 1000))
+    }
+}
+
 const codeDeployDeploymentId = {
     promise: () => ({ deploymentId: 'id' })
 }
 
 describe('CodeDeploy Deploy Application', () => {
+    const tempDir = path.join(__dirname, 'temp')
+
     // Creates a simple mock that always succeeds (at least for these tests)
     function createSuccessfulCodeDeploy(): CodeDeploy {
         const codeDeploy = new CodeDeploy() as any
@@ -63,6 +71,14 @@ describe('CodeDeploy Deploy Application', () => {
     // TODO https://github.com/aws/aws-toolkit-azure-devops/issues/167
     beforeAll(() => {
         SdkUtils.readResourcesFromRelativePath('../../build/src/tasks/CodeDeployDeployApplication/task.json')
+
+        if (!fs.existsSync(tempDir)) {
+            fs.mkdirSync(tempDir)
+        } else {
+            fs.emptyDirSync(tempDir)
+        }
+
+        process.env.TEMP = tempDir
     })
 
     test('Creates a TaskOperation', () => {
@@ -117,8 +133,6 @@ describe('CodeDeploy Deploy Application', () => {
         let parameters: TaskParameters
 
         beforeEach(() => {
-            process.env.TEMP = __dirname
-
             parameters = { ...defaultTaskParameters }
             parameters.deploymentRevisionSource = revisionSourceFromWorkspace
             parameters.revisionBundle = path.join(__dirname, '../../resources/codeDeployCode')
@@ -133,10 +147,10 @@ describe('CodeDeploy Deploy Application', () => {
                 expect(args.Bucket).toBe('')
                 expect(args.Key).toContain('test.v')
                 expect(args.ACL).toBeUndefined()
-                const dir = fs.readdirSync(__dirname)
+                const dir = fs.readdirSync(tempDir)
                 for (const file of dir) {
                     if (path.extname(file) === '.zip') {
-                        const f = path.join(__dirname, file)
+                        const f = path.join(tempDir, file)
                         const zip = new AdmZip(f)
                         const entries = zip.getEntries().map(it => it.entryName)
                         expect(entries.length).toBe(3)
@@ -147,7 +161,7 @@ describe('CodeDeploy Deploy Application', () => {
                     }
                 }
 
-                return emptyPromise
+                return sleepOneSecPromise
             })
 
             const taskOperations = new TaskOperations(createSuccessfulCodeDeploy(), s3, parameters)
@@ -162,7 +176,7 @@ describe('CodeDeploy Deploy Application', () => {
             s3.upload = jest.fn(args => {
                 expect(args.ACL).toBe('bucket-owner-full-control')
 
-                return emptyPromise
+                return sleepOneSecPromise
             })
 
             const taskOperations = new TaskOperations(createSuccessfulCodeDeploy(), s3, parameters)
@@ -177,7 +191,7 @@ describe('CodeDeploy Deploy Application', () => {
             s3.upload = jest.fn(args => {
                 expect(args.ACL).toBeUndefined()
 
-                return emptyPromise
+                return sleepOneSecPromise
             })
 
             const taskOperations = new TaskOperations(createSuccessfulCodeDeploy(), s3, parameters)


### PR DESCRIPTION
## Description

### Background
When executing our `codeDeployDeployApplication-test.ts` test suite, the unit tests would pass, but then immediately throw the following error: 
```
[Error: ENOENT: no such file or directory, open 'C:\Users\rbbarad\Desktop\azdo\public-repo\aws-toolkit-azure-devops\tests\taskTests\codeDeployDeployApplication\temp\test.v1705631182630.zip'] {
  errno: -4058,
  code: 'ENOENT',
  syscall: 'open',
  path: 'C:\\Users\\rbbarad\\Desktop\\azdo\\public-repo\\aws-toolkit-azure-devops\\tests\\taskTests\\codeDeployDeployApplication\\temp\\test.v1705631182630.zip'
}
```

This error would cause flakiness in our Linux Unit Tests, as it would throw this error and exceed the retry limit for the Linux CodeBuild job. 

### Problem 

The reason for this error is due to our use of `fs.createReadStream` for reading the file contents and passing them as the request `Body` to S3 Upload. The S3 Upload request allows a few different types for the Body request (`Buffer|string|etc.`), but the Readable Stream is the most efficient method since it doesn't need to finish reading the file into memory in order to begin uploading like the other types would. The `fs.createReadStream` line returns a stream for immediate use, but can/will continue to read the file into the stream afterward (as the S3 Upload occurs). The readStream will conclude reading the file as the S3 Upload process occurs - the real S3 Upload is equipped to handle this.

However in our Mocked S3 Upload, it returned success instantly, and then `cleanDeploymentArchive` would delete the file immediately after (while fs.ReadStream is still trying to read the file). This would successfully delete the file, but then throw the ENOENT error as it continues to try reading the now deleted file.


### Solution 
This change fixes this issue by adding a 1 second sleep to the S3 Upload Mock, which allows sufficient time for the readStream to finish reading our test's resource files


*Important:* The nature of this error is specific to our unit tests and not to actual task flows. This is because the fs.ReadStream must conclude as the S3 Upload is running/concluding. Any issues with the S3 Upload would be thrown/caught and errors with the readStream will be thrown caught as well (these would occur before any file deletion attempts). In real-world situations, the file would never be deleted while the stream is still reading. 

## Testing
- Ran tests locally.
- Replicated the linux codebuild job in my personal aws account and pointed those to my forked repo to confirm that this runs successfully.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have read the **README** document
-   [x] I have read the **CONTRIBUTING** document
-   [x] My code follows the code style of this project
-   [x] I have added tests to cover my changes
-   [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
