### PR TITLE
Revert azure-pipelines-task-lib to 2.12.2 to mitigate shelljs bundling issue

### DIFF
--- a/build-scripts/packageExtension.ts
+++ b/build-scripts/packageExtension.ts
@@ -118,8 +118,7 @@ function packagePlugin(options: CommandLineOptions) {
                 platform: 'node',
                 target: ['node10'],
                 minify: true,
-                outfile: `${taskPackageFolder}/${taskName}.js`,
-                external: ['shelljs'] // mitigates shelljs bundling issue -- https://github.com/microsoft/azure-pipelines-task-lib/issues/942
+                outfile: `${taskPackageFolder}/${taskName}.js`
             })
             result.warnings.forEach(warning => console.log(warning))
         } catch (err) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "@typescript-eslint/typescript-estree": "^4.17.0",
                 "adm-zip": "^0.5.3",
                 "aws-sdk": "^2.979.0",
-                "azure-pipelines-task-lib": "^3.3.1",
+                "azure-pipelines-task-lib": "^2.12.2",
                 "base-64": "^0.1.0",
                 "https-proxy-agent": "^5.0.0",
                 "js-yaml": "^3.13.1",
@@ -1629,6 +1629,7 @@
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/@types/concat-stream/-/concat-stream-1.6.0.tgz",
             "integrity": "sha1-OU2+C7X+5Gs42JZzXoto7yOQ0A0=",
+            "dev": true,
             "dependencies": {
                 "@types/node": "*"
             }
@@ -1666,6 +1667,7 @@
             "version": "0.0.33",
             "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-0.0.33.tgz",
             "integrity": "sha1-yayFsqX9GENbjIXZ7LUObWyJP/g=",
+            "dev": true,
             "dependencies": {
                 "@types/node": "*"
             }
@@ -1761,7 +1763,8 @@
         "node_modules/@types/node": {
             "version": "10.17.28",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.28.tgz",
-            "integrity": "sha512-dzjES1Egb4c1a89C7lKwQh8pwjYmlOAG9dW1pBgxEk57tMrLnssOfEthz8kdkNaBd7lIqQx7APm5+mZ619IiCQ=="
+            "integrity": "sha512-dzjES1Egb4c1a89C7lKwQh8pwjYmlOAG9dW1pBgxEk57tMrLnssOfEthz8kdkNaBd7lIqQx7APm5+mZ619IiCQ==",
+            "dev": true
         },
         "node_modules/@types/normalize-package-data": {
             "version": "2.4.0",
@@ -1790,7 +1793,8 @@
         "node_modules/@types/qs": {
             "version": "6.5.3",
             "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.5.3.tgz",
-            "integrity": "sha512-Jugo5V/1bS0fRhy2z8+cUAHEyWOATaz4rbyLVvcFs7+dXp5HfwpEwzF1Q11bB10ApUqHf+yTauxI0UXQDwGrbA=="
+            "integrity": "sha512-Jugo5V/1bS0fRhy2z8+cUAHEyWOATaz4rbyLVvcFs7+dXp5HfwpEwzF1Q11bB10ApUqHf+yTauxI0UXQDwGrbA==",
+            "dev": true
         },
         "node_modules/@types/readline-sync": {
             "version": "1.4.3",
@@ -2507,7 +2511,8 @@
         "node_modules/asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+            "dev": true
         },
         "node_modules/aws-sdk": {
             "version": "2.979.0",
@@ -2554,17 +2559,56 @@
             }
         },
         "node_modules/azure-pipelines-task-lib": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-3.3.1.tgz",
-            "integrity": "sha512-56ZAr4MHIoa24VNVuwPL4iUQ5MKaigPoYXkBG8E8fiVmh8yZdatUo25meNoQwg77vDY22F63Q44UzXoMWmy7ag==",
+            "version": "2.12.2",
+            "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-2.12.2.tgz",
+            "integrity": "sha512-ofAdVZcL90Qv6zYcKa1vK3Wnrl2kxoKX/Idvb7RWrqHQzcJlAEjCU4UCB5y6NnSKqRSyVTIhdS6hChphpOaiMQ==",
             "dependencies": {
-                "minimatch": "3.0.5",
+                "minimatch": "3.0.4",
                 "mockery": "^1.7.0",
-                "q": "^1.5.1",
+                "q": "^1.1.2",
                 "semver": "^5.1.0",
-                "shelljs": "^0.8.5",
-                "sync-request": "6.1.0",
+                "shelljs": "^0.3.0",
+                "sync-request": "3.0.1",
                 "uuid": "^3.0.1"
+            }
+        },
+        "node_modules/azure-pipelines-task-lib/node_modules/caseless": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+            "integrity": "sha512-ODLXH644w9C2fMPAm7bMDQ3GRvipZWZfKc+8As6hIadRIelE0n0xZuN38NS6kiK3KPEVrpymmQD8bvncAHWQkQ=="
+        },
+        "node_modules/azure-pipelines-task-lib/node_modules/http-basic": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/http-basic/-/http-basic-2.5.1.tgz",
+            "integrity": "sha512-q/qOkgjcnZ90v0wSaMwamhfAhIf6lhOsH0ehHFnQHAt1lA9MedSnmqEEnh8bq0njTBAK3IsmS2gEuXryfWCDkw==",
+            "dependencies": {
+                "caseless": "~0.11.0",
+                "concat-stream": "^1.4.6",
+                "http-response-object": "^1.0.0"
+            }
+        },
+        "node_modules/azure-pipelines-task-lib/node_modules/http-response-object": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-1.1.0.tgz",
+            "integrity": "sha512-adERueQxEMtIfGk4ee/9CG7AGUjS09OyHeKrubTjmHUsEVXesrGlZLWYnCL8fajPZIX9H4NDnXyyzBPrF078sA=="
+        },
+        "node_modules/azure-pipelines-task-lib/node_modules/minimatch": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/azure-pipelines-task-lib/node_modules/promise": {
+            "version": "7.3.1",
+            "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+            "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+            "dependencies": {
+                "asap": "~2.0.3"
             }
         },
         "node_modules/azure-pipelines-task-lib/node_modules/semver": {
@@ -2573,6 +2617,40 @@
             "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
             "bin": {
                 "semver": "bin/semver"
+            }
+        },
+        "node_modules/azure-pipelines-task-lib/node_modules/shelljs": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+            "integrity": "sha512-Ny0KN4dyT8ZSCE0frtcbAJGoM/HTArpyPkeli1/00aYfm0sbD/Gk/4x7N2DP9QKGpBsiQH7n6rpm1L79RtviEQ==",
+            "bin": {
+                "shjs": "bin/shjs"
+            },
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/azure-pipelines-task-lib/node_modules/sync-request": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/sync-request/-/sync-request-3.0.1.tgz",
+            "integrity": "sha512-bnOSypECs6aB9ScWHcJAkS9z55jOhO3tdLefLfJ+J58vC2HCi5tjxmFMxLv0RxvuAFFQ/G4BupVehqpAlbi+3Q==",
+            "dependencies": {
+                "concat-stream": "^1.4.7",
+                "http-response-object": "^1.0.1",
+                "then-request": "^2.0.1"
+            }
+        },
+        "node_modules/azure-pipelines-task-lib/node_modules/then-request": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/then-request/-/then-request-2.2.0.tgz",
+            "integrity": "sha512-YM/Fho1bQ3JFX9dgFQsBswc3aSTePXvtNHl3aXJTZNz/444yC86EVJR92aWMRNA0O9X0UfmojyCTUcT8Lbo5yA==",
+            "dependencies": {
+                "caseless": "~0.11.0",
+                "concat-stream": "^1.4.7",
+                "http-basic": "^2.5.1",
+                "http-response-object": "^1.1.0",
+                "promise": "^7.1.1",
+                "qs": "^6.1.0"
             }
         },
         "node_modules/babel-jest": {
@@ -2928,7 +3006,8 @@
         "node_modules/caseless": {
             "version": "0.12.0",
             "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+            "dev": true
         },
         "node_modules/chalk": {
             "version": "2.4.2",
@@ -3109,6 +3188,7 @@
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
             "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "dev": true,
             "dependencies": {
                 "delayed-stream": "~1.0.0"
             },
@@ -3402,6 +3482,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
             "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+            "dev": true,
             "engines": {
                 "node": ">=0.4.0"
             }
@@ -4628,6 +4709,7 @@
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
             "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+            "dev": true,
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.6",
@@ -4660,7 +4742,8 @@
         "node_modules/fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
         },
         "node_modules/fsevents": {
             "version": "2.3.2",
@@ -4731,6 +4814,7 @@
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
             "integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw=",
+            "dev": true,
             "engines": {
                 "node": ">=4"
             }
@@ -4763,6 +4847,7 @@
             "version": "7.1.4",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
             "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+            "dev": true,
             "dependencies": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -4895,6 +4980,7 @@
             "version": "8.1.3",
             "resolved": "https://registry.npmjs.org/http-basic/-/http-basic-8.1.3.tgz",
             "integrity": "sha512-/EcDMwJZh3mABI2NhGfHOGOeOZITqfkEO4p/xK+l3NpyncIHUQBoMvCSF/b5GqvKtySC2srL/GGG3+EtlqlmCw==",
+            "dev": true,
             "dependencies": {
                 "caseless": "^0.12.0",
                 "concat-stream": "^1.6.2",
@@ -4923,6 +5009,7 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-3.0.2.tgz",
             "integrity": "sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==",
+            "dev": true,
             "dependencies": {
                 "@types/node": "^10.0.3"
             }
@@ -5207,6 +5294,7 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dev": true,
             "dependencies": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -5221,6 +5309,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
             "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+            "dev": true,
             "engines": {
                 "node": ">= 0.10"
             }
@@ -5247,6 +5336,7 @@
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
             "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+            "dev": true,
             "dependencies": {
                 "has": "^1.0.3"
             },
@@ -7658,6 +7748,7 @@
             "version": "3.0.5",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
             "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
+            "dev": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -7901,6 +7992,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true,
             "dependencies": {
                 "wrappy": "1"
             }
@@ -8036,7 +8128,8 @@
         "node_modules/parse-cache-control": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
-            "integrity": "sha1-juqz5U+laSD+Fro493+iGqzC104="
+            "integrity": "sha1-juqz5U+laSD+Fro493+iGqzC104=",
+            "dev": true
         },
         "node_modules/parse-json": {
             "version": "5.2.0",
@@ -8075,6 +8168,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -8091,7 +8185,8 @@
         "node_modules/path-parse": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+            "dev": true
         },
         "node_modules/path-type": {
             "version": "4.0.0",
@@ -8307,6 +8402,7 @@
             "version": "8.0.3",
             "resolved": "https://registry.npmjs.org/promise/-/promise-8.0.3.tgz",
             "integrity": "sha512-HeRDUL1RJiLhyA0/grn+PTShlBAcLuh/1BJGtrvjwbvRDCTLLMEz9rOGCV+R3vHY4MixIuoMEd9Yq/XvsTPcjw==",
+            "dev": true,
             "dependencies": {
                 "asap": "~2.0.6"
             }
@@ -8522,6 +8618,7 @@
             "version": "0.6.2",
             "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
             "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+            "dev": true,
             "dependencies": {
                 "resolve": "^1.1.6"
             },
@@ -8582,6 +8679,7 @@
             "version": "1.22.0",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
             "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
+            "dev": true,
             "dependencies": {
                 "is-core-module": "^2.8.1",
                 "path-parse": "^1.0.7",
@@ -8819,6 +8917,7 @@
             "version": "0.8.5",
             "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
             "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+            "dev": true,
             "dependencies": {
                 "glob": "^7.0.0",
                 "interpret": "^1.0.0",
@@ -9174,6 +9273,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
             "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+            "dev": true,
             "engines": {
                 "node": ">= 0.4"
             },
@@ -9191,6 +9291,7 @@
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/sync-request/-/sync-request-6.1.0.tgz",
             "integrity": "sha512-8fjNkrNlNCrVc/av+Jn+xxqfCjYaBoHqCsDz6mt030UMxJGr+GSfCV1dQt2gRtlL63+VPidwDVLr7V2OcTSdRw==",
+            "dev": true,
             "dependencies": {
                 "http-response-object": "^3.0.1",
                 "sync-rpc": "^1.2.1",
@@ -9204,6 +9305,7 @@
             "version": "1.3.4",
             "resolved": "https://registry.npmjs.org/sync-rpc/-/sync-rpc-1.3.4.tgz",
             "integrity": "sha512-Iug+t1ICVFenUcTnDu8WXFnT+k8IVoLKGh8VA3eXUtl2Rt9SjKX3YEv33OenABqpTPL9QEaHv1+CNn2LK8vMow==",
+            "dev": true,
             "dependencies": {
                 "get-port": "^3.1.0"
             }
@@ -9565,6 +9667,7 @@
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/then-request/-/then-request-6.0.2.tgz",
             "integrity": "sha512-3ZBiG7JvP3wbDzA9iNY5zJQcHL4jn/0BWtXIkagfz7QgOL/LqjCEOBQuJNZfu0XYnv5JhKh+cDxCPM4ILrqruA==",
+            "dev": true,
             "dependencies": {
                 "@types/concat-stream": "^1.6.0",
                 "@types/form-data": "0.0.33",
@@ -9585,7 +9688,8 @@
         "node_modules/then-request/node_modules/@types/node": {
             "version": "8.10.49",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.49.tgz",
-            "integrity": "sha512-YX30JVx0PvSmJ3Eqr74fYLGeBxD+C7vIL20ek+GGGLJeUbVYRUW3EzyAXpIRA0K8c8o0UWqR/GwEFYiFoz1T8w=="
+            "integrity": "sha512-YX30JVx0PvSmJ3Eqr74fYLGeBxD+C7vIL20ek+GGGLJeUbVYRUW3EzyAXpIRA0K8c8o0UWqR/GwEFYiFoz1T8w==",
+            "dev": true
         },
         "node_modules/throat": {
             "version": "6.0.1",
@@ -10409,7 +10513,8 @@
         "node_modules/wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
         },
         "node_modules/write-file-atomic": {
             "version": "3.0.3",
@@ -11772,6 +11877,7 @@
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/@types/concat-stream/-/concat-stream-1.6.0.tgz",
             "integrity": "sha1-OU2+C7X+5Gs42JZzXoto7yOQ0A0=",
+            "dev": true,
             "requires": {
                 "@types/node": "*"
             }
@@ -11809,6 +11915,7 @@
             "version": "0.0.33",
             "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-0.0.33.tgz",
             "integrity": "sha1-yayFsqX9GENbjIXZ7LUObWyJP/g=",
+            "dev": true,
             "requires": {
                 "@types/node": "*"
             }
@@ -11904,7 +12011,8 @@
         "@types/node": {
             "version": "10.17.28",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.28.tgz",
-            "integrity": "sha512-dzjES1Egb4c1a89C7lKwQh8pwjYmlOAG9dW1pBgxEk57tMrLnssOfEthz8kdkNaBd7lIqQx7APm5+mZ619IiCQ=="
+            "integrity": "sha512-dzjES1Egb4c1a89C7lKwQh8pwjYmlOAG9dW1pBgxEk57tMrLnssOfEthz8kdkNaBd7lIqQx7APm5+mZ619IiCQ==",
+            "dev": true
         },
         "@types/normalize-package-data": {
             "version": "2.4.0",
@@ -11933,7 +12041,8 @@
         "@types/qs": {
             "version": "6.5.3",
             "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.5.3.tgz",
-            "integrity": "sha512-Jugo5V/1bS0fRhy2z8+cUAHEyWOATaz4rbyLVvcFs7+dXp5HfwpEwzF1Q11bB10ApUqHf+yTauxI0UXQDwGrbA=="
+            "integrity": "sha512-Jugo5V/1bS0fRhy2z8+cUAHEyWOATaz4rbyLVvcFs7+dXp5HfwpEwzF1Q11bB10ApUqHf+yTauxI0UXQDwGrbA==",
+            "dev": true
         },
         "@types/readline-sync": {
             "version": "1.4.3",
@@ -12473,7 +12582,8 @@
         "asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+            "dev": true
         },
         "aws-sdk": {
             "version": "2.979.0",
@@ -12514,23 +12624,87 @@
             }
         },
         "azure-pipelines-task-lib": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-3.3.1.tgz",
-            "integrity": "sha512-56ZAr4MHIoa24VNVuwPL4iUQ5MKaigPoYXkBG8E8fiVmh8yZdatUo25meNoQwg77vDY22F63Q44UzXoMWmy7ag==",
+            "version": "2.12.2",
+            "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-2.12.2.tgz",
+            "integrity": "sha512-ofAdVZcL90Qv6zYcKa1vK3Wnrl2kxoKX/Idvb7RWrqHQzcJlAEjCU4UCB5y6NnSKqRSyVTIhdS6hChphpOaiMQ==",
             "requires": {
-                "minimatch": "3.0.5",
+                "minimatch": "3.0.4",
                 "mockery": "^1.7.0",
-                "q": "^1.5.1",
+                "q": "^1.1.2",
                 "semver": "^5.1.0",
-                "shelljs": "^0.8.5",
-                "sync-request": "6.1.0",
+                "shelljs": "^0.3.0",
+                "sync-request": "3.0.1",
                 "uuid": "^3.0.1"
             },
             "dependencies": {
+                "caseless": {
+                    "version": "0.11.0",
+                    "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+                    "integrity": "sha512-ODLXH644w9C2fMPAm7bMDQ3GRvipZWZfKc+8As6hIadRIelE0n0xZuN38NS6kiK3KPEVrpymmQD8bvncAHWQkQ=="
+                },
+                "http-basic": {
+                    "version": "2.5.1",
+                    "resolved": "https://registry.npmjs.org/http-basic/-/http-basic-2.5.1.tgz",
+                    "integrity": "sha512-q/qOkgjcnZ90v0wSaMwamhfAhIf6lhOsH0ehHFnQHAt1lA9MedSnmqEEnh8bq0njTBAK3IsmS2gEuXryfWCDkw==",
+                    "requires": {
+                        "caseless": "~0.11.0",
+                        "concat-stream": "^1.4.6",
+                        "http-response-object": "^1.0.0"
+                    }
+                },
+                "http-response-object": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-1.1.0.tgz",
+                    "integrity": "sha512-adERueQxEMtIfGk4ee/9CG7AGUjS09OyHeKrubTjmHUsEVXesrGlZLWYnCL8fajPZIX9H4NDnXyyzBPrF078sA=="
+                },
+                "minimatch": {
+                    "version": "3.0.4",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                    "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+                    "requires": {
+                        "brace-expansion": "^1.1.7"
+                    }
+                },
+                "promise": {
+                    "version": "7.3.1",
+                    "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+                    "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+                    "requires": {
+                        "asap": "~2.0.3"
+                    }
+                },
                 "semver": {
                     "version": "5.7.1",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                     "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+                },
+                "shelljs": {
+                    "version": "0.3.0",
+                    "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+                    "integrity": "sha512-Ny0KN4dyT8ZSCE0frtcbAJGoM/HTArpyPkeli1/00aYfm0sbD/Gk/4x7N2DP9QKGpBsiQH7n6rpm1L79RtviEQ=="
+                },
+                "sync-request": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/sync-request/-/sync-request-3.0.1.tgz",
+                    "integrity": "sha512-bnOSypECs6aB9ScWHcJAkS9z55jOhO3tdLefLfJ+J58vC2HCi5tjxmFMxLv0RxvuAFFQ/G4BupVehqpAlbi+3Q==",
+                    "requires": {
+                        "concat-stream": "^1.4.7",
+                        "http-response-object": "^1.0.1",
+                        "then-request": "^2.0.1"
+                    }
+                },
+                "then-request": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/then-request/-/then-request-2.2.0.tgz",
+                    "integrity": "sha512-YM/Fho1bQ3JFX9dgFQsBswc3aSTePXvtNHl3aXJTZNz/444yC86EVJR92aWMRNA0O9X0UfmojyCTUcT8Lbo5yA==",
+                    "requires": {
+                        "caseless": "~0.11.0",
+                        "concat-stream": "^1.4.7",
+                        "http-basic": "^2.5.1",
+                        "http-response-object": "^1.1.0",
+                        "promise": "^7.1.1",
+                        "qs": "^6.1.0"
+                    }
                 }
             }
         },
@@ -12809,7 +12983,8 @@
         "caseless": {
             "version": "0.12.0",
             "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+            "dev": true
         },
         "chalk": {
             "version": "2.4.2",
@@ -12964,6 +13139,7 @@
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
             "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "dev": true,
             "requires": {
                 "delayed-stream": "~1.0.0"
             }
@@ -13205,7 +13381,8 @@
         "delayed-stream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+            "dev": true
         },
         "detect-newline": {
             "version": "3.1.0",
@@ -14022,6 +14199,7 @@
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
             "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+            "dev": true,
             "requires": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.6",
@@ -14048,7 +14226,8 @@
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
         },
         "fsevents": {
             "version": "2.3.2",
@@ -14099,7 +14278,8 @@
         "get-port": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
-            "integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw="
+            "integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw=",
+            "dev": true
         },
         "get-stdin": {
             "version": "8.0.0",
@@ -14117,6 +14297,7 @@
             "version": "7.1.4",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
             "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+            "dev": true,
             "requires": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -14216,6 +14397,7 @@
             "version": "8.1.3",
             "resolved": "https://registry.npmjs.org/http-basic/-/http-basic-8.1.3.tgz",
             "integrity": "sha512-/EcDMwJZh3mABI2NhGfHOGOeOZITqfkEO4p/xK+l3NpyncIHUQBoMvCSF/b5GqvKtySC2srL/GGG3+EtlqlmCw==",
+            "dev": true,
             "requires": {
                 "caseless": "^0.12.0",
                 "concat-stream": "^1.6.2",
@@ -14238,6 +14420,7 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-3.0.2.tgz",
             "integrity": "sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==",
+            "dev": true,
             "requires": {
                 "@types/node": "^10.0.3"
             }
@@ -14434,6 +14617,7 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dev": true,
             "requires": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -14447,7 +14631,8 @@
         "interpret": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-            "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="
+            "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+            "dev": true
         },
         "is-arrayish": {
             "version": "0.2.1",
@@ -14465,6 +14650,7 @@
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
             "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+            "dev": true,
             "requires": {
                 "has": "^1.0.3"
             }
@@ -16272,6 +16458,7 @@
             "version": "3.0.5",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
             "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
+            "dev": true,
             "requires": {
                 "brace-expansion": "^1.1.7"
             }
@@ -16467,6 +16654,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true,
             "requires": {
                 "wrappy": "1"
             }
@@ -16566,7 +16754,8 @@
         "parse-cache-control": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
-            "integrity": "sha1-juqz5U+laSD+Fro493+iGqzC104="
+            "integrity": "sha1-juqz5U+laSD+Fro493+iGqzC104=",
+            "dev": true
         },
         "parse-json": {
             "version": "5.2.0",
@@ -16595,7 +16784,8 @@
         "path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "dev": true
         },
         "path-key": {
             "version": "2.0.1",
@@ -16606,7 +16796,8 @@
         "path-parse": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+            "dev": true
         },
         "path-type": {
             "version": "4.0.0",
@@ -16763,6 +16954,7 @@
             "version": "8.0.3",
             "resolved": "https://registry.npmjs.org/promise/-/promise-8.0.3.tgz",
             "integrity": "sha512-HeRDUL1RJiLhyA0/grn+PTShlBAcLuh/1BJGtrvjwbvRDCTLLMEz9rOGCV+R3vHY4MixIuoMEd9Yq/XvsTPcjw==",
+            "dev": true,
             "requires": {
                 "asap": "~2.0.6"
             }
@@ -16926,6 +17118,7 @@
             "version": "0.6.2",
             "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
             "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+            "dev": true,
             "requires": {
                 "resolve": "^1.1.6"
             }
@@ -16968,6 +17161,7 @@
             "version": "1.22.0",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
             "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
+            "dev": true,
             "requires": {
                 "is-core-module": "^2.8.1",
                 "path-parse": "^1.0.7",
@@ -17133,6 +17327,7 @@
             "version": "0.8.5",
             "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
             "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+            "dev": true,
             "requires": {
                 "glob": "^7.0.0",
                 "interpret": "^1.0.0",
@@ -17409,7 +17604,8 @@
         "supports-preserve-symlinks-flag": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
+            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+            "dev": true
         },
         "symbol-tree": {
             "version": "3.2.4",
@@ -17421,6 +17617,7 @@
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/sync-request/-/sync-request-6.1.0.tgz",
             "integrity": "sha512-8fjNkrNlNCrVc/av+Jn+xxqfCjYaBoHqCsDz6mt030UMxJGr+GSfCV1dQt2gRtlL63+VPidwDVLr7V2OcTSdRw==",
+            "dev": true,
             "requires": {
                 "http-response-object": "^3.0.1",
                 "sync-rpc": "^1.2.1",
@@ -17431,6 +17628,7 @@
             "version": "1.3.4",
             "resolved": "https://registry.npmjs.org/sync-rpc/-/sync-rpc-1.3.4.tgz",
             "integrity": "sha512-Iug+t1ICVFenUcTnDu8WXFnT+k8IVoLKGh8VA3eXUtl2Rt9SjKX3YEv33OenABqpTPL9QEaHv1+CNn2LK8vMow==",
+            "dev": true,
             "requires": {
                 "get-port": "^3.1.0"
             }
@@ -17715,6 +17913,7 @@
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/then-request/-/then-request-6.0.2.tgz",
             "integrity": "sha512-3ZBiG7JvP3wbDzA9iNY5zJQcHL4jn/0BWtXIkagfz7QgOL/LqjCEOBQuJNZfu0XYnv5JhKh+cDxCPM4ILrqruA==",
+            "dev": true,
             "requires": {
                 "@types/concat-stream": "^1.6.0",
                 "@types/form-data": "0.0.33",
@@ -17732,7 +17931,8 @@
                 "@types/node": {
                     "version": "8.10.49",
                     "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.49.tgz",
-                    "integrity": "sha512-YX30JVx0PvSmJ3Eqr74fYLGeBxD+C7vIL20ek+GGGLJeUbVYRUW3EzyAXpIRA0K8c8o0UWqR/GwEFYiFoz1T8w=="
+                    "integrity": "sha512-YX30JVx0PvSmJ3Eqr74fYLGeBxD+C7vIL20ek+GGGLJeUbVYRUW3EzyAXpIRA0K8c8o0UWqR/GwEFYiFoz1T8w==",
+                    "dev": true
                 }
             }
         },
@@ -18352,7 +18552,8 @@
         "wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
         },
         "write-file-atomic": {
             "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
         "@typescript-eslint/typescript-estree": "^4.17.0",
         "adm-zip": "^0.5.3",
         "aws-sdk": "^2.979.0",
-        "azure-pipelines-task-lib": "^3.3.1",
+        "azure-pipelines-task-lib": "^2.12.2",
         "base-64": "^0.1.0",
         "https-proxy-agent": "^5.0.0",
         "js-yaml": "^3.13.1",


### PR DESCRIPTION
## Description

### Background

This is a follow-up pr to fix the issue in #522. 

[Mark shelljs as external for esbuild bundling](https://github.com/aws/aws-toolkit-azure-devops/pull/537)  attempted to address this issue, but was not a successful solution for all of our tasks, as some of our tasks need the commands present in ShellJS.

### Problem

This issue emerged with the bump of `azure-pipelines-task-lib` dependency in: https://github.com/aws/aws-toolkit-azure-devops/pull/473.

Problem detailed in the open issue on `azure-pipelines-task-lib` repo: [Cannot use JS bundler because of shelljs dependency](https://github.com/microsoft/azure-pipelines-task-lib/issues/942).

Essentially, the toolkit takes a dependency on `azure-pipelines-task-lib` which takes an additional dependency on ShellJS. Our toolkit uses the esbuild JS Bundler to build the extension. This fails to bundle ShellJS because it uses dynamic require statements ([problematic ShellJS code](https://github.com/shelljs/shelljs/blob/a6d1e49f180a495d83bcf67bd85782c626aae029/shell.js#L23-L26)) instead of explicit require statements, which prevents bundlers from correctly analyzing the dependencies.
-  In short, require('./a') works but require('./' + 'a') doesn't.

[ShellJS has no plans to accommodate these explicit requires statements](https://github.com/shelljs/shelljs/issues/962#issuecomment-583136465)

### Solution

Before making any larger scale changes, let's get `azure-pipelines-task-lib` back to its last known healthy state (working version we used for last release). This PR addresses that.

### Future `azure-pipelines-task-lib` updates
Whenever we next bump the `azure-pipelines-task-lib` major version, we'll need to keep an eye on updates to https://github.com/microsoft/azure-pipelines-task-lib/issues/942 for any new fixes or workarounds. Current known workarounds involve forking the ShellJS repository, making the necessary changes to ShellJS, and overriding the ShellJS dependency in `package.json` with the forked version.
- [Example of forked ShellJS with hardcoded explicit `requires` statements](https://github.com/Everspace/shelljs/commit/4e2ea23620baad3496a0fac8a2f016105ffa4c37)
- [Example of creating a bundler plugin with a fixed ShellJS file at compile time](https://github.com/tjosepo/azure-pipelines/blob/main/packages/esbuild-plugin-azure-pipelines-task-lib-fix/src/index.js) 

## Testing

- Ran unit tests
- ran tasks locally (using `node <path-to-task>`)  to confirm output matches expectations
- Ran tasks/pipelines on hosted server and confirmed they run successfully

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have read the **README** document
-   [x] I have read the **CONTRIBUTING** document
-   [x] My code follows the code style of this project
-   [ ] I have added tests to cover my changes
-   [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
