### PR TITLE
Fix beanstalkutils-test filename issue and improve log readability

### DIFF
--- a/tests/taskTests/common/beanstalkutils-test.ts
+++ b/tests/taskTests/common/beanstalkutils-test.ts
@@ -118,10 +118,10 @@ describe('BeanstalkUtils', () => {
         expect.assertions(1)
         const s3 = new S3() as any
         s3.upload = jest.fn(() => {
-            throw Error('it failed')
+            throw Error('Intentional beanstalkutils-test Error')
         })
-        await BeanstalkUtils.uploadBundle(s3, 'path', 'name', 'object').catch(err => {
-            expect(`${err}`).toContain('it failed')
+        await BeanstalkUtils.uploadBundle(s3, __filename, 'name', 'object').catch(err => {
+            expect(`${err}`).toContain('Intentional beanstalkutils-test Error')
         })
     })
 
@@ -131,11 +131,11 @@ describe('BeanstalkUtils', () => {
         s3.upload = jest.fn(args => {
             expect(args.Bucket).toEqual('name')
             expect(args.Key).toEqual('object')
-            expect(args.Body.path).toEqual(path.join(__dirname, __filename))
+            expect(args.Body.path).toEqual(__filename)
 
             return s3BucketResponse
         })
-        await BeanstalkUtils.uploadBundle(s3, path.join(__dirname, __filename), 'name', 'object')
+        await BeanstalkUtils.uploadBundle(s3, __filename, 'name', 'object')
     })
 
     test('VerifyApplicationExists throws on failure', async () => {


### PR DESCRIPTION
## Description

Fixes a few issues with `beanstalkutils-test.ts`

### Unhandled ENOENT error

This change fixes ENOENT errors similar to the one found in #538 

```
Error: ENOENT: no such file or directory, open 'C:\Users\rbbarad\Desktop\azdo\public-repo\aws-toolkit-azure-devops\tests\taskTests\common\C:\Users\rbbarad\Desktop\azdo\public-repo\aws-toolkit-azure-devops\tests\taskTests\common\beanstalkutils-test.ts'
Emitted 'error' event on ReadStream instance at:
    at emitErrorNT (node:internal/streams/destroy:151:8)
    at emitErrorCloseNT (node:internal/streams/destroy:116:3)
    at processTicksAndRejections (node:internal/process/task_queues:82:21) {
  errno: -4058,
  code: 'ENOENT',
  syscall: 'open',
  path: 'C:\\Users\\rbbarad\\Desktop\\azdo\\public-repo\\aws-toolkit-azure-devops\\tests\\taskTests\\common\\C:\\Users\\rbbarad\\Desktop\\azdo\\public-repo\\aws-toolkit-azure-devops\\tests\\taskTests\\common\\beanstalkutils-test.ts'
}
```
In this case, the issue was due to malformed paths (e.g. `path.join(__dirname, __filename)` instead of just `__filename`). 

Since this readStream error was previously unhandled and the test assertions still matched what was expected, our unit tests were still technically passing. However, it is the buildup of these types of errors across the test suite that contributes to the overall flakiness of our Unit tests (see #538). This change cleans that up for the beanstalk tests.

This change also adds the proper error handling for ReadableStreams.

### Log Readability

1. Our intentional 'expect this test to throw' type of tests still output the error to the logs. It isn't clear at first glance that these errors are expected since they look very similar to real errors that can come up. This adds description to the log output so that it is easier for future maintainers to discern

2. Removes a duplicated error message output

## Testing

- ran unit test suite locally

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have read the **README** document
-   [x] I have read the **CONTRIBUTING** document
-   [x] My code follows the code style of this project
-   [x] I have added tests to cover my changes
-   [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
