### PR TITLE
Azure DevOps OIDC

### DIFF
--- a/.changes/next-release/Feature-f63baff9-a19c-4522-b666-40a6b595b38c.json
+++ b/.changes/next-release/Feature-f63baff9-a19c-4522-b666-40a6b595b38c.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Add OIDC Auth Support"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
     "name": "aws-vsts-tools",
-    "version": "1.14.0",
+    "version": "1.14.14",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "aws-vsts-tools",
-            "version": "1.14.0",
+            "version": "1.14.14",
             "license": "apache",
             "dependencies": {
                 "@typescript-eslint/typescript-estree": "^4.17.0",
                 "adm-zip": "^0.5.3",
                 "aws-sdk": "^2.979.0",
+                "azure-devops-node-api": "^13.0.0",
                 "azure-pipelines-task-lib": "^2.12.2",
                 "base-64": "^0.1.0",
                 "https-proxy-agent": "^5.0.0",
@@ -2550,10 +2551,9 @@
             }
         },
         "node_modules/azure-devops-node-api": {
-            "version": "10.2.2",
-            "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-10.2.2.tgz",
-            "integrity": "sha512-4TVv2X7oNStT0vLaEfExmy3J4/CzfuXolEcQl/BRUmvGySqKStTG2O55/hUQ0kM7UJlZBLgniM0SBq4d/WkKow==",
-            "dev": true,
+            "version": "13.0.0",
+            "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-13.0.0.tgz",
+            "integrity": "sha512-T/i3pt2Dxb2//1+TJT05Ff5heUmQEWKwa8sdguIhdRYT3Zge9FYw98zpfFvCD7CZsz6AN74SKGgqF3ISVN2TGg==",
             "dependencies": {
                 "tunnel": "0.0.6",
                 "typed-rest-client": "^1.8.4"
@@ -9487,6 +9487,16 @@
             "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
             "dev": true
         },
+        "node_modules/tfx-cli/node_modules/azure-devops-node-api": {
+            "version": "10.2.2",
+            "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-10.2.2.tgz",
+            "integrity": "sha512-4TVv2X7oNStT0vLaEfExmy3J4/CzfuXolEcQl/BRUmvGySqKStTG2O55/hUQ0kM7UJlZBLgniM0SBq4d/WkKow==",
+            "dev": true,
+            "dependencies": {
+                "tunnel": "0.0.6",
+                "typed-rest-client": "^1.8.4"
+            }
+        },
         "node_modules/tfx-cli/node_modules/bl": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
@@ -9924,7 +9934,6 @@
             "version": "0.0.6",
             "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
             "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
-            "dev": true,
             "engines": {
                 "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
             }
@@ -9963,7 +9972,6 @@
             "version": "1.8.6",
             "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.6.tgz",
             "integrity": "sha512-xcQpTEAJw2DP7GqVNECh4dD+riS+C1qndXLfBCJ3xk0kqprtGN491P5KlmrDbKdtuW8NEcP/5ChxiJI3S9WYTA==",
-            "dev": true,
             "dependencies": {
                 "qs": "^6.9.1",
                 "tunnel": "0.0.6",
@@ -9999,8 +10007,7 @@
         "node_modules/underscore": {
             "version": "1.13.3",
             "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.3.tgz",
-            "integrity": "sha512-QvjkYpiD+dJJraRA8+dGAU4i7aBbb2s0S3jA45TFOvg2VgqvdCDd/3N6CqA8gluk1W91GLoXg5enMUx560QzuA==",
-            "dev": true
+            "integrity": "sha512-QvjkYpiD+dJJraRA8+dGAU4i7aBbb2s0S3jA45TFOvg2VgqvdCDd/3N6CqA8gluk1W91GLoXg5enMUx560QzuA=="
         },
         "node_modules/universalify": {
             "version": "0.1.2",
@@ -12522,10 +12529,9 @@
             }
         },
         "azure-devops-node-api": {
-            "version": "10.2.2",
-            "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-10.2.2.tgz",
-            "integrity": "sha512-4TVv2X7oNStT0vLaEfExmy3J4/CzfuXolEcQl/BRUmvGySqKStTG2O55/hUQ0kM7UJlZBLgniM0SBq4d/WkKow==",
-            "dev": true,
+            "version": "13.0.0",
+            "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-13.0.0.tgz",
+            "integrity": "sha512-T/i3pt2Dxb2//1+TJT05Ff5heUmQEWKwa8sdguIhdRYT3Zge9FYw98zpfFvCD7CZsz6AN74SKGgqF3ISVN2TGg==",
             "requires": {
                 "tunnel": "0.0.6",
                 "typed-rest-client": "^1.8.4"
@@ -17657,6 +17663,16 @@
                     "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
                     "dev": true
                 },
+                "azure-devops-node-api": {
+                    "version": "10.2.2",
+                    "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-10.2.2.tgz",
+                    "integrity": "sha512-4TVv2X7oNStT0vLaEfExmy3J4/CzfuXolEcQl/BRUmvGySqKStTG2O55/hUQ0kM7UJlZBLgniM0SBq4d/WkKow==",
+                    "dev": true,
+                    "requires": {
+                        "tunnel": "0.0.6",
+                        "typed-rest-client": "^1.8.4"
+                    }
+                },
                 "bl": {
                     "version": "1.2.3",
                     "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
@@ -17974,8 +17990,7 @@
         "tunnel": {
             "version": "0.0.6",
             "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
-            "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
-            "dev": true
+            "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
         },
         "type-check": {
             "version": "0.3.2",
@@ -18002,7 +18017,6 @@
             "version": "1.8.6",
             "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.6.tgz",
             "integrity": "sha512-xcQpTEAJw2DP7GqVNECh4dD+riS+C1qndXLfBCJ3xk0kqprtGN491P5KlmrDbKdtuW8NEcP/5ChxiJI3S9WYTA==",
-            "dev": true,
             "requires": {
                 "qs": "^6.9.1",
                 "tunnel": "0.0.6",
@@ -18031,8 +18045,7 @@
         "underscore": {
             "version": "1.13.3",
             "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.3.tgz",
-            "integrity": "sha512-QvjkYpiD+dJJraRA8+dGAU4i7aBbb2s0S3jA45TFOvg2VgqvdCDd/3N6CqA8gluk1W91GLoXg5enMUx560QzuA==",
-            "dev": true
+            "integrity": "sha512-QvjkYpiD+dJJraRA8+dGAU4i7aBbb2s0S3jA45TFOvg2VgqvdCDd/3N6CqA8gluk1W91GLoXg5enMUx560QzuA=="
         },
         "universalify": {
             "version": "0.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "aws-vsts-tools",
-    "version": "1.14.14",
+    "version": "1.15.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "aws-vsts-tools",
-            "version": "1.14.14",
+            "version": "1.15.0",
             "license": "apache",
             "dependencies": {
                 "@typescript-eslint/typescript-estree": "^4.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "aws-vsts-tools",
-    "version": "1.14.0",
+    "version": "1.15.0",
     "description": "AWS Tools for Azure DevOps",
     "private": true,
     "main": "build/tasks",
@@ -83,6 +83,7 @@
         "@typescript-eslint/typescript-estree": "^4.17.0",
         "adm-zip": "^0.5.3",
         "aws-sdk": "^2.979.0",
+        "azure-devops-node-api": "^13.0.0",
         "azure-pipelines-task-lib": "^2.12.2",
         "base-64": "^0.1.0",
         "https-proxy-agent": "^5.0.0",

--- a/src/lib/vstsUtils.ts
+++ b/src/lib/vstsUtils.ts
@@ -78,7 +78,7 @@ export function getPathInputRequiredCheck(name: string): string {
 export function getVariableRequired(name: string): string {
     const variable = getVariable(name)
     if (!variable) {
-        throw new Error(`Unreachable code, required variable '${name}' returned undefined!`)
+        throw new Error(`Rrequired variable '${name}' returned undefined!`)
     }
 
     return variable

--- a/src/tasks/AWSPowerShellModuleScript/task.json
+++ b/src/tasks/AWSPowerShellModuleScript/task.json
@@ -6,8 +6,13 @@
     "author": "Amazon Web Services",
     "helpMarkDown": "Run a PowerShell script that uses cmdlets from the [AWS Tools for Windows PowerShell module (AWSPowerShell)](https://www.powershellgallery.com/packages/AWSPowerShell) module. The module will be automatically installed if needed.\n\nMore information on this task can be found in the [task reference](https://docs.aws.amazon.com/vsts/latest/userguide/awspowershell-module-script.html).\n\n####Task Permissions\nPermissions for this task to call AWS service APIs depend on the activities in the supplied script.",
     "category": "Deploy",
-    "visibility": ["Build", "Release"],
-    "demands": ["DotNetFramework"],
+    "visibility": [
+        "Build",
+        "Release"
+    ],
+    "demands": [
+        "DotNetFramework"
+    ],
     "minimumAgentVersion": "2.144.0",
     "instanceNameFormat": "AWS Tools for Windows PowerShell Script: $(scriptFile)",
     "showEnvironmentVariables": true,
@@ -126,7 +131,9 @@
     "execution": {
         "PowerShell3": {
             "target": "RunAWSPowerShellModuleScript.ps1",
-            "platforms": ["windows"]
+            "platforms": [
+                "windows"
+            ]
         }
     },
     "messages": {
@@ -146,7 +153,8 @@
         "ProxyConfigError": "Failed to configure proxy, error {0}",
         "SkippingProxyConfigDueToAgentVersion": "Agent version {0} does not meet minumum {1} for proxy configuration; skipping auto-detection of proxy settings.",
         "CheckingForProxyConfiguration": "Attempting to detect proxy settings to configure tool",
-        "ConfiguringForRoleCredentials": "Configuring task to use role-scoped credentials from specified endpoint",
+        "ConfiguringForRoleCredentialsFromAccessKeys": "Configuring task to use role-scoped credentials from specified endpoint",
+        "ConfiguringForRoleCredentialsFromOIDC": "Configuring task to use role-scoped credentials from specified endpoint assumed using the Azure DevOps OIDC token",
         "ConfiguringForStandardCredentials": "Configuring task for standard AWS credentials from specified endpoint",
         "ConfiguringForTaskVariableCredentials": "Configuring task for standard AWS credentials from task variables",
         "MissingSecretKeyVariable": "AWS access key ID present in task variables but secret key value is missing; cannot configure task credentials"

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -272,36 +272,6 @@
                                     "isRequired": false,
                                     "dataType": "string"
                                 }
-                            },
-                            {
-                                "id": "serviceprincipalid",
-                                "name": "Service Principal Id",
-                                "inputMode": "textbox",
-                                "isConfidential": false,
-                                "validation": {
-                                    "isRequired": false,
-                                    "dataType": "guid"
-                                },
-                                "values": {
-                                    "inputId": "serviceprincipalid",
-                                    "defaultValue": "",
-                                    "isDisabled": true
-                                }
-                            },
-                            {
-                                "id": "tenantid",
-                                "name": "Tenant ID",
-                                "inputMode": "textbox",
-                                "isConfidential": false,
-                                "validation": {
-                                    "isRequired": false,
-                                    "dataType": "guid"
-                                },
-                                "values": {
-                                    "inputId": "tenantid",
-                                    "defaultValue": "",
-                                    "isDisabled": true
-                                }
                             }
                         ]
                     }

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -1,9 +1,13 @@
 {
     "manifestVersion": 1,
     "id": "aws-vsts-tools",
-    "version": "1.1.8",
+    "version": "1.2.0",
     "name": "AWS Toolkit for Azure DevOps",
-    "scopes": ["vso.build", "vso.build_execute", "vso.release"],
+    "scopes": [
+        "vso.build",
+        "vso.build_execute",
+        "vso.release"
+    ],
     "description": "Tasks for Amazon S3, AWS Elastic Beanstalk, AWS CodeDeploy, AWS Lambda and AWS CloudFormation and more, and running commands in the AWS Tools for Windows PowerShell module and the AWS CLI.",
     "publisher": "unknown",
     "public": false,
@@ -143,13 +147,17 @@
             "path": "Tasks/SystemsManagerSetParameter"
         }
     ],
-    "categories": ["Azure Pipelines"],
+    "categories": [
+        "Azure Pipelines"
+    ],
     "contributions": [
         {
-            "id": "aws-credentials",
+            "id": "aws-credentials-services",
             "description": "Credentials for tasks invoking AWS services",
             "type": "ms.vss-endpoint.service-endpoint-type",
-            "targets": ["ms.vss-endpoint.endpoint-types"],
+            "targets": [
+                "ms.vss-endpoint.endpoint-types"
+            ],
             "properties": {
                 "name": "AWS",
                 "displayName": "AWS",
@@ -169,11 +177,12 @@
                 "authenticationSchemes": [
                     {
                         "type": "ms.vss-endpoint.endpoint-auth-scheme-basic",
+                        "displayName": "AWS Access Key",
                         "inputDescriptors": [
                             {
                                 "id": "username",
                                 "name": "Access Key ID",
-                                "description": "The AWS access key ID for signing programmatic requests.\nExample: AKIAIOSFODNN7EXAMPLE. Not needed when using instance profiles.",
+                                "description": "The AWS access key ID for signing programmatic requests.<br>Example: AKIAIOSFODNN7EXAMPLE. Not needed when using instance profiles.",
                                 "inputMode": "textbox",
                                 "isConfidential": false,
                                 "validation": {
@@ -184,7 +193,7 @@
                             {
                                 "id": "password",
                                 "name": "Secret Access Key",
-                                "description": "The AWS secret access key for signing programmatic requests.\nExample: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY. Not needed when using instance profiles.",
+                                "description": "The AWS secret access key for signing programmatic requests.<br>Example: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY. Not needed when using instance profiles.",
                                 "inputMode": "passwordbox",
                                 "isConfidential": true,
                                 "validation": {
@@ -195,7 +204,7 @@
                             {
                                 "id": "sessionToken",
                                 "name": "Session Token",
-                                "description": "The AWS session token for signing programmatic requests.\nNote: Only use this if you have an external rotation mechanism)",
+                                "description": "The AWS session token for signing programmatic requests.<br>Note: Only use this if you have an external rotation mechanism)",
                                 "inputMode": "passwordbox",
                                 "isConfidential": true,
                                 "validation": {
@@ -206,7 +215,7 @@
                             {
                                 "id": "assumeRoleArn",
                                 "name": "Role to Assume",
-                                "description": "The Amazon Resource Name (ARN) of the role to assume.\nIf a role ARN is specified the access and secret keys configured in the endpoint will be used to generate temporary session credentials, scoped to the specified role, and used be used by the task.\nThe generated credentials for each AWS task will be valid for a default duration of 15 minutes. If your tasks need a longer duration (up to a maximum of one hour) set the variable 'aws.rolecredential.maxduration' on your build or release definition to the required duration (in seconds, minimum 900 and maximum 43200). Note that this setting will affect all tasks that use AWS endpoints configured to assume a role.",
+                                "description": "The Amazon Resource Name (ARN) of the role to assume.<br>If a role ARN is specified the access and secret keys configured in the endpoint will be used to generate temporary session credentials, scoped to the specified role, and used be used by the task.<br>The generated credentials for each AWS task will be valid for a default duration of 15 minutes. If your tasks need a longer duration (up to a maximum of one hour) set the variable 'aws.rolecredential.maxduration' on your build or release definition to the required duration (in seconds, minimum 900 and maximum 43200). Note that this setting will affect all tasks that use AWS endpoints configured to assume a role.",
                                 "inputMode": "textbox",
                                 "isConfidential": false,
                                 "validation": {
@@ -217,7 +226,7 @@
                             {
                                 "id": "roleSessionName",
                                 "name": "Role Session Name",
-                                "description": "Optional identifier for the assumed role session. If not specified the tasks will use a default name of 'aws-vsts-tools'.\nUse the role session name to uniquely identify a session when the same role is assumed by different principals or for different reasons. In cross-account scenarios, the role session name is visible to, and can be logged by the account that owns the role. The role session name is also used in the ARN of the assumed role principal. This means that subsequent cross-account API requests using the temporary security credentials will expose the role session name to the external account in their CloudTrail logs.",
+                                "description": "Optional identifier for the assumed role session. If not specified the tasks will use a default name of 'aws-vsts-tools'.<br>Use the role session name to uniquely identify a session when the same role is assumed by different principals or for different reasons. In cross-account scenarios, the role session name is visible to, and can be logged by the account that owns the role. The role session name is also used in the ARN of the assumed role principal. This means that subsequent cross-account API requests using the temporary security credentials will expose the role session name to the external account in their CloudTrail logs.",
                                 "inputMode": "textbox",
                                 "isConfidential": false,
                                 "validation": {
@@ -237,6 +246,64 @@
                                 }
                             }
                         ]
+                    },
+                    {
+                        "type": "ms.vss-endpoint.endpoint-auth-scheme-none",
+                        "displayName": "Azure DevOps OIDC (Services only)",
+                        "inputDescriptors": [
+                            {
+                                "id": "role",
+                                "name": "Role to Assume",
+                                "description": "The Amazon Resource Name (ARN) of the role to assume.<br><br>The Azure DevOps OIDC token for this endpoint will be used to generate temporary session credentials, scoped to the specified role, and used be used by the task.<br>The generated credentials for each AWS task will be valid for a default duration of 15 minutes. If your tasks need a longer duration (up to a maximum of one hour) set the variable 'aws.rolecredential.maxduration' on your build or release definition to the required duration (in seconds, minimum 900 and maximum 43200). Note that this setting will affect all tasks that use AWS endpoints configured to assume a role.<br><br>AWS tasks log the OIDC token claims needed to <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc.html\">configure an OIDC provider</a> & roles in AWS IAM.",
+                                "inputMode": "textbox",
+                                "isConfidential": false,
+                                "validation": {
+                                    "isRequired": true,
+                                    "dataType": "string"
+                                }
+                            },
+                            {
+                                "id": "roleSessionName",
+                                "name": "Role Session Name",
+                                "description": "Optional identifier for the assumed role session. If not specified the tasks will use a default name of 'aws-vsts-tools'.<br>Use the role session name to uniquely identify a session when the same role is assumed by different principals or for different reasons. In cross-account scenarios, the role session name is visible to, and can be logged by the account that owns the role. The role session name is also used in the ARN of the assumed role principal. This means that subsequent cross-account API requests using the temporary security credentials will expose the role session name to the external account in their CloudTrail logs.",
+                                "inputMode": "textbox",
+                                "isConfidential": false,
+                                "validation": {
+                                    "isRequired": false,
+                                    "dataType": "string"
+                                }
+                            },
+                            {
+                                "id": "serviceprincipalid",
+                                "name": "Service Principal Id",
+                                "inputMode": "textbox",
+                                "isConfidential": false,
+                                "validation": {
+                                    "isRequired": false,
+                                    "dataType": "guid"
+                                },
+                                "values": {
+                                    "inputId": "serviceprincipalid",
+                                    "defaultValue": "",
+                                    "isDisabled": true
+                                }
+                            },
+                            {
+                                "id": "tenantid",
+                                "name": "Tenant ID",
+                                "inputMode": "textbox",
+                                "isConfidential": false,
+                                "validation": {
+                                    "isRequired": false,
+                                    "dataType": "guid"
+                                },
+                                "values": {
+                                    "inputId": "tenantid",
+                                    "defaultValue": "",
+                                    "isDisabled": true
+                                }
+                            }
+                        ]
                     }
                 ],
                 "helpMarkDown": "<a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_create.html?icmpid=docs_iam_console\" target=\"_blank\"><b>Learn More</b></a>"
@@ -246,7 +313,9 @@
             "id": "AWSCLI",
             "description": "Run an AWS CLI command against an AWS connection",
             "type": "ms.vss-distributed-task.task",
-            "targets": ["ms.vss-distributed-task.tasks"],
+            "targets": [
+                "ms.vss-distributed-task.tasks"
+            ],
             "properties": {
                 "name": "Tasks/AWSCLI"
             }
@@ -255,7 +324,9 @@
             "id": "AWSPowerShellModuleScript",
             "description": "Run a PowerShell script that uses cmdlets from the AWS Tools for Windows PowerShell module.",
             "type": "ms.vss-distributed-task.task",
-            "targets": ["ms.vss-distributed-task.tasks"],
+            "targets": [
+                "ms.vss-distributed-task.tasks"
+            ],
             "properties": {
                 "name": "Tasks/AWSPowerShellModuleScript"
             }
@@ -264,7 +335,9 @@
             "id": "AWSShellScript",
             "description": "Run a shell script using Bash with AWS credentials.",
             "type": "ms.vss-distributed-task.task",
-            "targets": ["ms.vss-distributed-task.tasks"],
+            "targets": [
+                "ms.vss-distributed-task.tasks"
+            ],
             "properties": {
                 "name": "Tasks/AWSShellScript"
             }
@@ -273,7 +346,9 @@
             "id": "BeanstalkCreateApplicationVersion",
             "description": "Create a new application version for later deployment to AWS Elastic Beanstalk",
             "type": "ms.vss-distributed-task.task",
-            "targets": ["ms.vss-distributed-task.tasks"],
+            "targets": [
+                "ms.vss-distributed-task.tasks"
+            ],
             "properties": {
                 "name": "Tasks/BeanstalkCreateApplicationVersion"
             }
@@ -282,7 +357,9 @@
             "id": "BeanstalkDeployApplication",
             "description": "Deploy an application to AWS Elastic Beanstalk",
             "type": "ms.vss-distributed-task.task",
-            "targets": ["ms.vss-distributed-task.tasks"],
+            "targets": [
+                "ms.vss-distributed-task.tasks"
+            ],
             "properties": {
                 "name": "Tasks/BeanstalkDeployApplication"
             }
@@ -291,7 +368,9 @@
             "id": "CloudFormationCreateOrUpdateStack",
             "description": "Create or update an AWS CloudFormation stack",
             "type": "ms.vss-distributed-task.task",
-            "targets": ["ms.vss-distributed-task.tasks"],
+            "targets": [
+                "ms.vss-distributed-task.tasks"
+            ],
             "properties": {
                 "name": "Tasks/CloudFormationCreateOrUpdateStack"
             }
@@ -300,7 +379,9 @@
             "id": "CloudFormationDeleteStack",
             "description": "Deletes an AWS CloudFormation stack",
             "type": "ms.vss-distributed-task.task",
-            "targets": ["ms.vss-distributed-task.tasks"],
+            "targets": [
+                "ms.vss-distributed-task.tasks"
+            ],
             "properties": {
                 "name": "Tasks/CloudFormationDeleteStack"
             }
@@ -309,7 +390,9 @@
             "id": "CloudFormationExecuteChangeSet",
             "description": "Executes an AWS CloudFormation change set",
             "type": "ms.vss-distributed-task.task",
-            "targets": ["ms.vss-distributed-task.tasks"],
+            "targets": [
+                "ms.vss-distributed-task.tasks"
+            ],
             "properties": {
                 "name": "Tasks/CloudFormationExecuteChangeSet"
             }
@@ -318,7 +401,9 @@
             "id": "CodeDeployDeployApplication",
             "description": "Deploy an application to Amazon EC2 instances using AWS CodeDeploy",
             "type": "ms.vss-distributed-task.task",
-            "targets": ["ms.vss-distributed-task.tasks"],
+            "targets": [
+                "ms.vss-distributed-task.tasks"
+            ],
             "properties": {
                 "name": "Tasks/CodeDeployDeployApplication"
             }
@@ -327,7 +412,9 @@
             "id": "ECRPullImage",
             "description": "Pull an Elastic Container Registry image",
             "type": "ms.vss-distributed-task.task",
-            "targets": ["ms.vss-distributed-task.tasks"],
+            "targets": [
+                "ms.vss-distributed-task.tasks"
+            ],
             "properties": {
                 "name": "Tasks/ECRPullImage"
             }
@@ -336,7 +423,9 @@
             "id": "ECRPushImage",
             "description": "Push a local Docker image to Elastic Container Registry",
             "type": "ms.vss-distributed-task.task",
-            "targets": ["ms.vss-distributed-task.tasks"],
+            "targets": [
+                "ms.vss-distributed-task.tasks"
+            ],
             "properties": {
                 "name": "Tasks/ECRPushImage"
             }
@@ -345,7 +434,9 @@
             "id": "LambdaDeployFunction",
             "description": "General purpose deployment for AWS Lambda functions",
             "type": "ms.vss-distributed-task.task",
-            "targets": ["ms.vss-distributed-task.tasks"],
+            "targets": [
+                "ms.vss-distributed-task.tasks"
+            ],
             "properties": {
                 "name": "Tasks/LambdaDeployFunction"
             }
@@ -354,7 +445,9 @@
             "id": "LambdaInvokeFunction",
             "description": "Invokes an AWS Lambda function with a JSON payload",
             "type": "ms.vss-distributed-task.task",
-            "targets": ["ms.vss-distributed-task.tasks"],
+            "targets": [
+                "ms.vss-distributed-task.tasks"
+            ],
             "properties": {
                 "name": "Tasks/LambdaInvokeFunction"
             }
@@ -363,7 +456,9 @@
             "id": "LambdaNETCoreDeploy",
             "description": "Build and deploy a .NET Core AWS Lambda function",
             "type": "ms.vss-distributed-task.task",
-            "targets": ["ms.vss-distributed-task.tasks"],
+            "targets": [
+                "ms.vss-distributed-task.tasks"
+            ],
             "properties": {
                 "name": "Tasks/LambdaNETCoreDeploy"
             }
@@ -372,7 +467,9 @@
             "id": "S3Download",
             "description": "Download files from an Amazon Simple Storage Service (S3) Bucket",
             "type": "ms.vss-distributed-task.task",
-            "targets": ["ms.vss-distributed-task.tasks"],
+            "targets": [
+                "ms.vss-distributed-task.tasks"
+            ],
             "properties": {
                 "name": "Tasks/S3Download"
             }
@@ -381,7 +478,9 @@
             "id": "S3Upload",
             "description": "Upload files to an Amazon Simple Storage Service (S3) Bucket",
             "type": "ms.vss-distributed-task.task",
-            "targets": ["ms.vss-distributed-task.tasks"],
+            "targets": [
+                "ms.vss-distributed-task.tasks"
+            ],
             "properties": {
                 "name": "Tasks/S3Upload"
             }
@@ -390,7 +489,9 @@
             "id": "SecretsManagerCreateOrUpdateSecret",
             "description": "Updates a secret, optionally creating a secret if it does not exist",
             "type": "ms.vss-distributed-task.task",
-            "targets": ["ms.vss-distributed-task.tasks"],
+            "targets": [
+                "ms.vss-distributed-task.tasks"
+            ],
             "properties": {
                 "name": "Tasks/SecretsManagerCreateOrUpdateSecret"
             }
@@ -399,7 +500,9 @@
             "id": "SecretsManagerGetSecret",
             "description": "Stores the value of a secret in AWS Secrets Manager into a secret build variable",
             "type": "ms.vss-distributed-task.task",
-            "targets": ["ms.vss-distributed-task.tasks"],
+            "targets": [
+                "ms.vss-distributed-task.tasks"
+            ],
             "properties": {
                 "name": "Tasks/SecretsManagerGetSecret"
             }
@@ -408,7 +511,9 @@
             "id": "SendMessage",
             "description": "Sends a message to an SNS topic or SQS queue",
             "type": "ms.vss-distributed-task.task",
-            "targets": ["ms.vss-distributed-task.tasks"],
+            "targets": [
+                "ms.vss-distributed-task.tasks"
+            ],
             "properties": {
                 "name": "Tasks/SendMessage"
             }
@@ -417,7 +522,9 @@
             "id": "SystemsManagerGetParameter",
             "description": "Read one or more Systems Manager Parameter Store values into build variables",
             "type": "ms.vss-distributed-task.task",
-            "targets": ["ms.vss-distributed-task.tasks"],
+            "targets": [
+                "ms.vss-distributed-task.tasks"
+            ],
             "properties": {
                 "name": "Tasks/SystemsManagerGetParameter"
             }
@@ -426,7 +533,9 @@
             "id": "SystemsManagerRunCommand",
             "description": "Run a command remotely on a fleet of EC2 instances and/or on-premise machines",
             "type": "ms.vss-distributed-task.task",
-            "targets": ["ms.vss-distributed-task.tasks"],
+            "targets": [
+                "ms.vss-distributed-task.tasks"
+            ],
             "properties": {
                 "name": "Tasks/SystemsManagerRunCommand"
             }
@@ -435,7 +544,9 @@
             "id": "SystemsManagerSetParameter",
             "description": "Creates or updates a parameter value in the Systems Manager Parameter Store.",
             "type": "ms.vss-distributed-task.task",
-            "targets": ["ms.vss-distributed-task.tasks"],
+            "targets": [
+                "ms.vss-distributed-task.tasks"
+            ],
             "properties": {
                 "name": "Tasks/SystemsManagerSetParameter"
             }


### PR DESCRIPTION
## Description
This change allows AWS connections from Azure DevOps to use OIDC authentication to AWS instead of stored access tokens. Microsoft also calls this "Workload Identity Federation".

## Motivation
Using long lived credentials for authenticating into AWS is highly discouraged and incurs the manual overhead of managing those credentials. This process uses short lived OIDC tokens generated by Azure DevOps which are generated for each run and authenticated by AWS and a configured OIDC IdP to provide temporary credentials for a role.

## Related Issue(s), If Filed

#521 

## Testing

I've been testing this during in an Azure DevOps Services account, the change is not applicable to the Azure DevOps Server product but I have confirmed that it does not break plugin installation for it. I tested primarily against the AWSPowerShellModuleScript and the AWSCLI task, some more testing is probably warranted though the rest of the tasks seem to leverage the authentication code that I updated.

## Checklist

-   [x] I have read the **README** document
-   [x] I have read the **CONTRIBUTING** document
-   [x] My code follows the code style of this project
-   [ ] I have added tests to cover my changes
-   [x] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
