### PR TITLE
fix: allow tasks to run with node16

### DIFF
--- a/.changes/next-release/Bug Fix-5d3f157d-ea54-439c-8674-56ee0cb0f3cb.json
+++ b/.changes/next-release/Bug Fix-5d3f157d-ea54-439c-8674-56ee0cb0f3cb.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "Support Node16"
+}

--- a/build-scripts/packageExtension.ts
+++ b/build-scripts/packageExtension.ts
@@ -116,7 +116,7 @@ function packagePlugin(options: CommandLineOptions) {
                 entryPoints: [inputFilename],
                 bundle: true,
                 platform: 'node',
-                target: ['node10'],
+                target: ['node10', 'node16'],
                 minify: true,
                 outfile: `${taskPackageFolder}/${taskName}.js`
             })

--- a/src/tasks/AWSCLI/task.json
+++ b/src/tasks/AWSCLI/task.json
@@ -76,6 +76,10 @@
         "Node10": {
             "target": "AWSCLI.js",
             "argumentFormat": ""
+        },
+        "Node16": {
+            "target": "AWSCLI.js",
+            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/AWSShellScript/task.json
+++ b/src/tasks/AWSShellScript/task.json
@@ -115,6 +115,10 @@
         "Node10": {
             "target": "AWSShellScript.js",
             "argumentFormat": ""
+        },
+        "Node16": {
+            "target": "AWSShellScript.js",
+            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/BeanstalkCreateApplicationVersion/task.json
+++ b/src/tasks/BeanstalkCreateApplicationVersion/task.json
@@ -143,6 +143,10 @@
         "Node10": {
             "target": "BeanstalkCreateApplicationVersion.js",
             "argumentFormat": ""
+        },
+        "Node16": {
+            "target": "BeanstalkCreateApplicationVersion.js",
+            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/BeanstalkDeployApplication/task.json
+++ b/src/tasks/BeanstalkDeployApplication/task.json
@@ -160,6 +160,10 @@
         "Node10": {
             "target": "BeanstalkDeployApplication.js",
             "argumentFormat": ""
+        },
+        "Node16": {
+            "target": "BeanstalkDeployApplication.js",
+            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/CloudFormationCreateOrUpdateStack/task.json
+++ b/src/tasks/CloudFormationCreateOrUpdateStack/task.json
@@ -380,6 +380,10 @@
         "Node10": {
             "target": "CloudFormationCreateOrUpdateStack.js",
             "argumentFormat": ""
+        },
+        "Node16": {
+            "target": "CloudFormationCreateOrUpdateStack.js",
+            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/CloudFormationDeleteStack/task.json
+++ b/src/tasks/CloudFormationDeleteStack/task.json
@@ -70,6 +70,10 @@
         "Node10": {
             "target": "CloudFormationDeleteStack.js",
             "argumentFormat": ""
+        },
+        "Node16": {
+            "target": "CloudFormationDeleteStack.js",
+            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/CloudFormationExecuteChangeSet/task.json
+++ b/src/tasks/CloudFormationExecuteChangeSet/task.json
@@ -133,6 +133,10 @@
         "Node10": {
             "target": "CloudFormationExecuteChangeSet.js",
             "argumentFormat": ""
+        },
+        "Node16": {
+            "target": "CloudFormationExecuteChangeSet.js",
+            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/CodeDeployDeployApplication/task.json
+++ b/src/tasks/CodeDeployDeployApplication/task.json
@@ -207,6 +207,10 @@
         "Node10": {
             "target": "CodeDeployDeployApplication.js",
             "argumentFormat": ""
+        },
+        "Node16": {
+            "target": "CodeDeployDeployApplication.js",
+            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/ECRPullImage/task.json
+++ b/src/tasks/ECRPullImage/task.json
@@ -116,6 +116,10 @@
         "Node10": {
             "target": "ECRPullImage.js",
             "argumentFormat": ""
+        },
+        "Node16": {
+            "target": "ECRPullImage.js",
+            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/ECRPushImage/task.json
+++ b/src/tasks/ECRPushImage/task.json
@@ -157,6 +157,10 @@
         "Node10": {
             "target": "ECRPushImage.js",
             "argumentFormat": ""
+        },
+        "Node16": {
+            "target": "ECRPushImage.js",
+            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/LambdaDeployFunction/task.json
+++ b/src/tasks/LambdaDeployFunction/task.json
@@ -306,6 +306,10 @@
         "Node10": {
             "target": "LambdaDeployFunction.js",
             "argumentFormat": ""
+        },
+        "Node16": {
+            "target": "LambdaDeployFunction.js",
+            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/LambdaInvokeFunction/task.json
+++ b/src/tasks/LambdaInvokeFunction/task.json
@@ -113,6 +113,10 @@
         "Node10": {
             "target": "LambdaInvokeFunction.js",
             "argumentFormat": ""
+        },
+        "Node16": {
+            "target": "LambdaInvokeFunction.js",
+            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/LambdaNETCoreDeploy/task.json
+++ b/src/tasks/LambdaNETCoreDeploy/task.json
@@ -176,6 +176,10 @@
         "Node10": {
             "target": "LambdaNETCoreDeploy.js",
             "argumentFormat": ""
+        },
+        "Node16": {
+            "target": "LambdaNETCoreDeploy.js",
+            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/S3Download/task.json
+++ b/src/tasks/S3Download/task.json
@@ -153,6 +153,10 @@
         "Node10": {
             "target": "S3Download.js",
             "argumentFormat": ""
+        },
+        "Node16": {
+            "target": "S3Download.js",
+            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/S3Upload/task.json
+++ b/src/tasks/S3Upload/task.json
@@ -235,6 +235,10 @@
         "Node10": {
             "target": "S3Upload.js",
             "argumentFormat": ""
+        },
+        "Node16": {
+            "target": "S3Upload.js",
+            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/SecretsManagerCreateOrUpdateSecret/task.json
+++ b/src/tasks/SecretsManagerCreateOrUpdateSecret/task.json
@@ -168,6 +168,10 @@
         "Node10": {
             "target": "SecretsManagerCreateOrUpdateSecret.js",
             "argumentFormat": ""
+        },
+        "Node16": {
+            "target": "SecretsManagerCreateOrUpdateSecret.js",
+            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/SecretsManagerGetSecret/task.json
+++ b/src/tasks/SecretsManagerGetSecret/task.json
@@ -93,6 +93,10 @@
         "Node10": {
             "target": "SecretsManagerGetSecret.js",
             "argumentFormat": ""
+        },
+        "Node16": {
+            "target": "SecretsManagerGetSecret.js",
+            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/SendMessage/task.json
+++ b/src/tasks/SendMessage/task.json
@@ -108,6 +108,10 @@
         "Node10": {
             "target": "SendMessage.js",
             "argumentFormat": ""
+        },
+        "Node16": {
+            "target": "SendMessage.js",
+            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/SystemsManagerGetParameter/task.json
+++ b/src/tasks/SystemsManagerGetParameter/task.json
@@ -183,6 +183,10 @@
         "Node10": {
             "target": "SystemsManagerGetParameter.js",
             "argumentFormat": ""
+        },
+        "Node16": {
+            "target": "SystemsManagerGetParameter.js",
+            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/SystemsManagerRunCommand/task.json
+++ b/src/tasks/SystemsManagerRunCommand/task.json
@@ -274,6 +274,10 @@
         "Node10": {
             "target": "SystemsManagerRunCommand.js",
             "argumentFormat": ""
+        },
+        "Node16": {
+            "target": "SystemsManagerRunCommand.js",
+            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/SystemsManagerSetParameter/task.json
+++ b/src/tasks/SystemsManagerSetParameter/task.json
@@ -99,6 +99,10 @@
         "Node10": {
             "target": "SystemsManagerSetParameter.js",
             "argumentFormat": ""
+        },
+        "Node16": {
+            "target": "SystemsManagerSetParameter.js",
+            "argumentFormat": ""
         }
     },
     "messages": {


### PR DESCRIPTION
## Description

Adds Node 16 as an execution target for the tasks.

## Motivation

Node 10 is removed in the latest release (v3.238.0) of azure-pipelines-agent (the release version that ships without Node 6 support). Agents running this version are currently not able to run tasks from this extension. Attempting to do so will halt the pipeline with the following message:

> ##[error]This step requires a node version that does not exist in the agent filesystem. Path: /opt/azure-pipelines-agent/externals/node10/bin/node

For now, we've held back on upgrading to the latest version of azure-pipelines-agent.

## Related Issue(s), If Filed

This has been raised in #548, where I've added some comments.

## Testing

I've run `npm run fullBuild` with both Node 16 and 18, which seems to have finished successfully. I have not attempted to install and run this with an updated agent yet.

## Checklist

-   [x] I have read the **README** document
-   [x] I have read the **CONTRIBUTING** document
-   [x] My code follows the code style of this project
-   [ ] I have added tests to cover my changes
-   [x] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
