### PR TITLE
Use shell for extension packaging only on Windows OS

### DIFF
--- a/build-scripts/packageExtension.ts
+++ b/build-scripts/packageExtension.ts
@@ -142,7 +142,9 @@ function packagePlugin(options: CommandLineOptions) {
 
     console.log('Packaging with:' + `${tfx} ${args.join(' ')}`)
 
-    ncp.execFileSync(tfx, args, { stdio: 'inherit', shell: true })
+    const output = ncp.execFileSync(tfx, args, { stdio: 'inherit', shell: true })
+
+    console.log('Output: ', output.toString())
 
     console.log('Packaging successful')
 }

--- a/build-scripts/packageExtension.ts
+++ b/build-scripts/packageExtension.ts
@@ -144,7 +144,7 @@ function packagePlugin(options: CommandLineOptions) {
 
     ncp.execFileSync(tfx, args, {
         stdio: 'inherit',
-        shell: os.platform() === 'win32'
+        shell: os.platform() === 'win32' // for tfx.cmd on Windows.
     })
 
     console.log('Packaging successful')

--- a/build-scripts/packageExtension.ts
+++ b/build-scripts/packageExtension.ts
@@ -142,9 +142,10 @@ function packagePlugin(options: CommandLineOptions) {
 
     console.log('Packaging with:' + `${tfx} ${args.join(' ')}`)
 
-    const output = ncp.execFileSync(tfx, args, { stdio: 'inherit', shell: true })
-
-    console.log('Output: ', output.toString())
+    ncp.execFileSync(tfx, args, {
+        stdio: 'inherit',
+        shell: os.platform() === 'win32'
+    })
 
     console.log('Packaging successful')
 }

--- a/build-scripts/packageExtension.ts
+++ b/build-scripts/packageExtension.ts
@@ -142,7 +142,7 @@ function packagePlugin(options: CommandLineOptions) {
 
     console.log('Packaging with:' + `${tfx} ${args.join(' ')}`)
 
-    ncp.execFileSync(tfx, args, { stdio: 'pipe', shell: true })
+    ncp.execFileSync(tfx, args, { stdio: 'inherit', shell: true })
 
     console.log('Packaging successful')
 }


### PR DESCRIPTION
## Description

1) Only uses shell for extension packaging on Windows OS - shell is not needed on other OS.
2) changes stdio to `inherit` for better info in our logs 

This is a follow up PR to https://github.com/aws/aws-toolkit-azure-devops/pull/552

## Motivation

<!--- Why is this change required? What problem does it solve? -->

Our ubuntu-based CI is having issues running this packaging step in a shell. Shell isn't necessary for non-windows OS, so this PR fixes that issue.

## Related PR(s)
- https://github.com/aws/aws-toolkit-vscode/pull/4947

## License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
