### PR TITLE
Revert "fix: allow tasks to run with node16"

### DIFF
--- a/.changes/next-release/Bug Fix-5d3f157d-ea54-439c-8674-56ee0cb0f3cb.json
+++ b/.changes/next-release/Bug Fix-5d3f157d-ea54-439c-8674-56ee0cb0f3cb.json
@@ -1,4 +1,0 @@
-{
-	"type": "Bug Fix",
-	"description": "Support Node16"
-}

--- a/build-scripts/packageExtension.ts
+++ b/build-scripts/packageExtension.ts
@@ -116,7 +116,7 @@ function packagePlugin(options: CommandLineOptions) {
                 entryPoints: [inputFilename],
                 bundle: true,
                 platform: 'node',
-                target: ['node10', 'node16'],
+                target: ['node10'],
                 minify: true,
                 outfile: `${taskPackageFolder}/${taskName}.js`
             })

--- a/src/tasks/AWSCLI/task.json
+++ b/src/tasks/AWSCLI/task.json
@@ -76,10 +76,6 @@
         "Node10": {
             "target": "AWSCLI.js",
             "argumentFormat": ""
-        },
-        "Node16": {
-            "target": "AWSCLI.js",
-            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/AWSShellScript/task.json
+++ b/src/tasks/AWSShellScript/task.json
@@ -115,10 +115,6 @@
         "Node10": {
             "target": "AWSShellScript.js",
             "argumentFormat": ""
-        },
-        "Node16": {
-            "target": "AWSShellScript.js",
-            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/BeanstalkCreateApplicationVersion/task.json
+++ b/src/tasks/BeanstalkCreateApplicationVersion/task.json
@@ -143,10 +143,6 @@
         "Node10": {
             "target": "BeanstalkCreateApplicationVersion.js",
             "argumentFormat": ""
-        },
-        "Node16": {
-            "target": "BeanstalkCreateApplicationVersion.js",
-            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/BeanstalkDeployApplication/task.json
+++ b/src/tasks/BeanstalkDeployApplication/task.json
@@ -160,10 +160,6 @@
         "Node10": {
             "target": "BeanstalkDeployApplication.js",
             "argumentFormat": ""
-        },
-        "Node16": {
-            "target": "BeanstalkDeployApplication.js",
-            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/CloudFormationCreateOrUpdateStack/task.json
+++ b/src/tasks/CloudFormationCreateOrUpdateStack/task.json
@@ -380,10 +380,6 @@
         "Node10": {
             "target": "CloudFormationCreateOrUpdateStack.js",
             "argumentFormat": ""
-        },
-        "Node16": {
-            "target": "CloudFormationCreateOrUpdateStack.js",
-            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/CloudFormationDeleteStack/task.json
+++ b/src/tasks/CloudFormationDeleteStack/task.json
@@ -70,10 +70,6 @@
         "Node10": {
             "target": "CloudFormationDeleteStack.js",
             "argumentFormat": ""
-        },
-        "Node16": {
-            "target": "CloudFormationDeleteStack.js",
-            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/CloudFormationExecuteChangeSet/task.json
+++ b/src/tasks/CloudFormationExecuteChangeSet/task.json
@@ -133,10 +133,6 @@
         "Node10": {
             "target": "CloudFormationExecuteChangeSet.js",
             "argumentFormat": ""
-        },
-        "Node16": {
-            "target": "CloudFormationExecuteChangeSet.js",
-            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/CodeDeployDeployApplication/task.json
+++ b/src/tasks/CodeDeployDeployApplication/task.json
@@ -207,10 +207,6 @@
         "Node10": {
             "target": "CodeDeployDeployApplication.js",
             "argumentFormat": ""
-        },
-        "Node16": {
-            "target": "CodeDeployDeployApplication.js",
-            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/ECRPullImage/task.json
+++ b/src/tasks/ECRPullImage/task.json
@@ -116,10 +116,6 @@
         "Node10": {
             "target": "ECRPullImage.js",
             "argumentFormat": ""
-        },
-        "Node16": {
-            "target": "ECRPullImage.js",
-            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/ECRPushImage/task.json
+++ b/src/tasks/ECRPushImage/task.json
@@ -157,10 +157,6 @@
         "Node10": {
             "target": "ECRPushImage.js",
             "argumentFormat": ""
-        },
-        "Node16": {
-            "target": "ECRPushImage.js",
-            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/LambdaDeployFunction/task.json
+++ b/src/tasks/LambdaDeployFunction/task.json
@@ -306,10 +306,6 @@
         "Node10": {
             "target": "LambdaDeployFunction.js",
             "argumentFormat": ""
-        },
-        "Node16": {
-            "target": "LambdaDeployFunction.js",
-            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/LambdaInvokeFunction/task.json
+++ b/src/tasks/LambdaInvokeFunction/task.json
@@ -113,10 +113,6 @@
         "Node10": {
             "target": "LambdaInvokeFunction.js",
             "argumentFormat": ""
-        },
-        "Node16": {
-            "target": "LambdaInvokeFunction.js",
-            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/LambdaNETCoreDeploy/task.json
+++ b/src/tasks/LambdaNETCoreDeploy/task.json
@@ -176,10 +176,6 @@
         "Node10": {
             "target": "LambdaNETCoreDeploy.js",
             "argumentFormat": ""
-        },
-        "Node16": {
-            "target": "LambdaNETCoreDeploy.js",
-            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/S3Download/task.json
+++ b/src/tasks/S3Download/task.json
@@ -153,10 +153,6 @@
         "Node10": {
             "target": "S3Download.js",
             "argumentFormat": ""
-        },
-        "Node16": {
-            "target": "S3Download.js",
-            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/S3Upload/task.json
+++ b/src/tasks/S3Upload/task.json
@@ -235,10 +235,6 @@
         "Node10": {
             "target": "S3Upload.js",
             "argumentFormat": ""
-        },
-        "Node16": {
-            "target": "S3Upload.js",
-            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/SecretsManagerCreateOrUpdateSecret/task.json
+++ b/src/tasks/SecretsManagerCreateOrUpdateSecret/task.json
@@ -168,10 +168,6 @@
         "Node10": {
             "target": "SecretsManagerCreateOrUpdateSecret.js",
             "argumentFormat": ""
-        },
-        "Node16": {
-            "target": "SecretsManagerCreateOrUpdateSecret.js",
-            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/SecretsManagerGetSecret/task.json
+++ b/src/tasks/SecretsManagerGetSecret/task.json
@@ -93,10 +93,6 @@
         "Node10": {
             "target": "SecretsManagerGetSecret.js",
             "argumentFormat": ""
-        },
-        "Node16": {
-            "target": "SecretsManagerGetSecret.js",
-            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/SendMessage/task.json
+++ b/src/tasks/SendMessage/task.json
@@ -108,10 +108,6 @@
         "Node10": {
             "target": "SendMessage.js",
             "argumentFormat": ""
-        },
-        "Node16": {
-            "target": "SendMessage.js",
-            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/SystemsManagerGetParameter/task.json
+++ b/src/tasks/SystemsManagerGetParameter/task.json
@@ -183,10 +183,6 @@
         "Node10": {
             "target": "SystemsManagerGetParameter.js",
             "argumentFormat": ""
-        },
-        "Node16": {
-            "target": "SystemsManagerGetParameter.js",
-            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/SystemsManagerRunCommand/task.json
+++ b/src/tasks/SystemsManagerRunCommand/task.json
@@ -274,10 +274,6 @@
         "Node10": {
             "target": "SystemsManagerRunCommand.js",
             "argumentFormat": ""
-        },
-        "Node16": {
-            "target": "SystemsManagerRunCommand.js",
-            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/SystemsManagerSetParameter/task.json
+++ b/src/tasks/SystemsManagerSetParameter/task.json
@@ -99,10 +99,6 @@
         "Node10": {
             "target": "SystemsManagerSetParameter.js",
             "argumentFormat": ""
-        },
-        "Node16": {
-            "target": "SystemsManagerSetParameter.js",
-            "argumentFormat": ""
         }
     },
     "messages": {


### PR DESCRIPTION
Reverts aws/aws-toolkit-azure-devops#551

We need to temporarily revert this commit to unblock a release. 

Supporting node 16 requires bumping `azure-pipelines-task-lib`. We are currently blocked from doing this because this version bump uses a newer version of `shelljs` as a dependency, which produces runtime errors for our task. (see PR description in https://github.com/aws/aws-toolkit-azure-devops/pull/539 for more details). 

To unblock ourselves, we will revert this commit as we investigate a workaround for the shelljs bundling issue