### PR TITLE
Fix typo in the sample OIDC trust policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ One or more service endpoints, of type _AWS_, can be created and populated with 
                 "Condition": {
                     "StringEquals": {
                         "vstoken.dev.azure.com/{org-id}:sub": "sc://{orgName}/{ProjectName}/{ServiceConnections}",
-                        "vstoken.dev.azure.com/{org-id}": "api://AzureADTokenExchange"
+                        "vstoken.dev.azure.com/{org-id}:aud": "api://AzureADTokenExchange"
                     }
                 }
             }


### PR DESCRIPTION
Fixes a typo in the sample OIDC trust policy

## License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
