### PR TITLE
feat(node): support node 20 in tasks

### DIFF
--- a/.changes/next-release/Feature-cb2222ff-2158-4c85-ab41-b109d7f42092.json
+++ b/.changes/next-release/Feature-cb2222ff-2158-4c85-ab41-b109d7f42092.json
@@ -1,0 +1,4 @@
+{
+	"type": "Feature",
+	"description": "Tasks now support Node 20"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,14 +1,7 @@
 {
-    "files.exclude": {
-        "build": true,
-        "package": true,
-        "package-lock.json": true,
-        ".vscode": true
-    },
+    "files.exclude": {},
     "search.exclude": {
-        "build": true,
-        "package": true,
-        ".vscode": true
+        "package": true
     },
     "json.schemas": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "adm-zip": "^0.5.3",
                 "aws-sdk": "^2.979.0",
                 "azure-devops-node-api": "^14.0.1",
-                "azure-pipelines-task-lib": "^2.12.2",
+                "azure-pipelines-task-lib": "^4.17.3",
                 "base-64": "^0.1.0",
                 "https-proxy-agent": "^5.0.0",
                 "js-yaml": "^3.13.1",
@@ -2285,11 +2285,12 @@
             }
         },
         "node_modules/adm-zip": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.3.tgz",
-            "integrity": "sha512-zsoTXEwRNCxBzRHLENFLuecCcwzzXiEhWo1r3GP68iwi8Q/hW2RrqgeY1nfJ/AhNQNWnZq/4v0TbfMsUkI+TYw==",
+            "version": "0.5.16",
+            "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
+            "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+            "license": "MIT",
             "engines": {
-                "node": ">=6.0"
+                "node": ">=12.0"
             }
         },
         "node_modules/agent-base": {
@@ -2465,11 +2466,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/asap": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-            "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
-        },
         "node_modules/astral-regex": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -2563,98 +2559,27 @@
             }
         },
         "node_modules/azure-pipelines-task-lib": {
-            "version": "2.12.2",
-            "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-2.12.2.tgz",
-            "integrity": "sha512-ofAdVZcL90Qv6zYcKa1vK3Wnrl2kxoKX/Idvb7RWrqHQzcJlAEjCU4UCB5y6NnSKqRSyVTIhdS6hChphpOaiMQ==",
+            "version": "4.17.3",
+            "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.17.3.tgz",
+            "integrity": "sha512-UxfH5pk3uOHTi9TtLtdDyugQVkFES5A836ZEePjcs3jYyxm3EJ6IlFYq6gbfd6mNBhrM9fxG2u/MFYIJ+Z0cxQ==",
+            "license": "MIT",
             "dependencies": {
-                "minimatch": "3.0.4",
-                "mockery": "^1.7.0",
-                "q": "^1.1.2",
-                "semver": "^5.1.0",
-                "shelljs": "^0.3.0",
-                "sync-request": "3.0.1",
+                "adm-zip": "^0.5.10",
+                "minimatch": "3.0.5",
+                "nodejs-file-downloader": "^4.11.1",
+                "q": "^1.5.1",
+                "semver": "^5.7.2",
+                "shelljs": "^0.8.5",
                 "uuid": "^3.0.1"
             }
         },
-        "node_modules/azure-pipelines-task-lib/node_modules/caseless": {
-            "version": "0.11.0",
-            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-            "integrity": "sha512-ODLXH644w9C2fMPAm7bMDQ3GRvipZWZfKc+8As6hIadRIelE0n0xZuN38NS6kiK3KPEVrpymmQD8bvncAHWQkQ=="
-        },
-        "node_modules/azure-pipelines-task-lib/node_modules/http-basic": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/http-basic/-/http-basic-2.5.1.tgz",
-            "integrity": "sha512-q/qOkgjcnZ90v0wSaMwamhfAhIf6lhOsH0ehHFnQHAt1lA9MedSnmqEEnh8bq0njTBAK3IsmS2gEuXryfWCDkw==",
-            "dependencies": {
-                "caseless": "~0.11.0",
-                "concat-stream": "^1.4.6",
-                "http-response-object": "^1.0.0"
-            }
-        },
-        "node_modules/azure-pipelines-task-lib/node_modules/http-response-object": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-1.1.0.tgz",
-            "integrity": "sha512-adERueQxEMtIfGk4ee/9CG7AGUjS09OyHeKrubTjmHUsEVXesrGlZLWYnCL8fajPZIX9H4NDnXyyzBPrF078sA=="
-        },
-        "node_modules/azure-pipelines-task-lib/node_modules/minimatch": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/azure-pipelines-task-lib/node_modules/promise": {
-            "version": "7.3.1",
-            "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-            "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-            "dependencies": {
-                "asap": "~2.0.3"
-            }
-        },
         "node_modules/azure-pipelines-task-lib/node_modules/semver": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+            "version": "5.7.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+            "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+            "license": "ISC",
             "bin": {
                 "semver": "bin/semver"
-            }
-        },
-        "node_modules/azure-pipelines-task-lib/node_modules/shelljs": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
-            "integrity": "sha512-Ny0KN4dyT8ZSCE0frtcbAJGoM/HTArpyPkeli1/00aYfm0sbD/Gk/4x7N2DP9QKGpBsiQH7n6rpm1L79RtviEQ==",
-            "bin": {
-                "shjs": "bin/shjs"
-            },
-            "engines": {
-                "node": ">=0.8.0"
-            }
-        },
-        "node_modules/azure-pipelines-task-lib/node_modules/sync-request": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/sync-request/-/sync-request-3.0.1.tgz",
-            "integrity": "sha512-bnOSypECs6aB9ScWHcJAkS9z55jOhO3tdLefLfJ+J58vC2HCi5tjxmFMxLv0RxvuAFFQ/G4BupVehqpAlbi+3Q==",
-            "dependencies": {
-                "concat-stream": "^1.4.7",
-                "http-response-object": "^1.0.1",
-                "then-request": "^2.0.1"
-            }
-        },
-        "node_modules/azure-pipelines-task-lib/node_modules/then-request": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/then-request/-/then-request-2.2.0.tgz",
-            "integrity": "sha512-YM/Fho1bQ3JFX9dgFQsBswc3aSTePXvtNHl3aXJTZNz/444yC86EVJR92aWMRNA0O9X0UfmojyCTUcT8Lbo5yA==",
-            "dependencies": {
-                "caseless": "~0.11.0",
-                "concat-stream": "^1.4.7",
-                "http-basic": "^2.5.1",
-                "http-response-object": "^1.1.0",
-                "promise": "^7.1.1",
-                "qs": "^6.1.0"
             }
         },
         "node_modules/babel-jest": {
@@ -2948,7 +2873,8 @@
         "node_modules/buffer-from": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-            "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+            "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+            "dev": true
         },
         "node_modules/call-bind": {
             "version": "1.0.2",
@@ -3212,20 +3138,6 @@
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
-        "node_modules/concat-stream": {
-            "version": "1.6.2",
-            "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-            "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-            "engines": [
-                "node >= 0.8"
-            ],
-            "dependencies": {
-                "buffer-from": "^1.0.0",
-                "inherits": "^2.0.3",
-                "readable-stream": "^2.2.2",
-                "typedarray": "^0.0.6"
-            }
-        },
         "node_modules/convert-source-map": {
             "version": "1.8.0",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
@@ -3238,7 +3150,8 @@
         "node_modules/core-util-is": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+            "dev": true
         },
         "node_modules/cosmiconfig": {
             "version": "7.0.1",
@@ -4716,7 +4629,6 @@
             "version": "1.15.6",
             "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
             "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
-            "dev": true,
             "funding": [
                 {
                     "type": "individual",
@@ -4755,8 +4667,7 @@
         "node_modules/fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-            "dev": true
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
         "node_modules/fsevents": {
             "version": "2.3.2",
@@ -4851,7 +4762,6 @@
             "version": "7.1.4",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
             "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-            "dev": true,
             "dependencies": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -5274,7 +5184,6 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-            "dev": true,
             "dependencies": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -5289,7 +5198,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
             "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
-            "dev": true,
             "engines": {
                 "node": ">= 0.10"
             }
@@ -5316,7 +5224,6 @@
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
             "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
-            "dev": true,
             "dependencies": {
                 "has": "^1.0.3"
             },
@@ -7738,7 +7645,6 @@
             "version": "3.0.5",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
             "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
-            "dev": true,
             "dependencies": {
                 "brace-expansion": "^1.1.7"
             },
@@ -7777,11 +7683,6 @@
             "engines": {
                 "node": ">=10"
             }
-        },
-        "node_modules/mockery": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/mockery/-/mockery-1.7.0.tgz",
-            "integrity": "sha1-9O3g2HUMHJcnwnLqLGBiniyaHE8="
         },
         "node_modules/mri": {
             "version": "1.1.4",
@@ -7852,6 +7753,18 @@
             "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.2.tgz",
             "integrity": "sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg==",
             "dev": true
+        },
+        "node_modules/nodejs-file-downloader": {
+            "version": "4.13.0",
+            "resolved": "https://registry.npmjs.org/nodejs-file-downloader/-/nodejs-file-downloader-4.13.0.tgz",
+            "integrity": "sha512-nI2fKnmJWWFZF6SgMPe1iBodKhfpztLKJTtCtNYGhm/9QXmWa/Pk9Sv00qHgzEvNLe1x7hjGDRor7gcm/ChaIQ==",
+            "license": "ISC",
+            "dependencies": {
+                "follow-redirects": "^1.15.6",
+                "https-proxy-agent": "^5.0.0",
+                "mime-types": "^2.1.27",
+                "sanitize-filename": "^1.6.3"
+            }
         },
         "node_modules/normalize-package-data": {
             "version": "2.5.0",
@@ -7982,7 +7895,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-            "dev": true,
             "dependencies": {
                 "wrappy": "1"
             }
@@ -8152,7 +8064,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -8169,8 +8080,7 @@
         "node_modules/path-parse": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-            "dev": true
+            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
         },
         "node_modules/path-type": {
             "version": "4.0.0",
@@ -8371,7 +8281,8 @@
         "node_modules/process-nextick-args": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-            "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+            "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+            "dev": true
         },
         "node_modules/progress": {
             "version": "2.0.3",
@@ -8576,6 +8487,7 @@
             "version": "2.3.6",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
             "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+            "dev": true,
             "dependencies": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -8599,7 +8511,6 @@
             "version": "0.6.2",
             "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
             "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-            "dev": true,
             "dependencies": {
                 "resolve": "^1.1.6"
             },
@@ -8660,7 +8571,6 @@
             "version": "1.22.0",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
             "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
-            "dev": true,
             "dependencies": {
                 "is-core-module": "^2.8.1",
                 "path-parse": "^1.0.7",
@@ -8770,13 +8680,23 @@
         "node_modules/safe-buffer": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "dev": true
         },
         "node_modules/safer-buffer": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
             "dev": true
+        },
+        "node_modules/sanitize-filename": {
+            "version": "1.6.3",
+            "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
+            "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
+            "license": "WTFPL OR ISC",
+            "dependencies": {
+                "truncate-utf8-bytes": "^1.0.0"
+            }
         },
         "node_modules/sax": {
             "version": "1.2.1",
@@ -8898,7 +8818,6 @@
             "version": "0.8.5",
             "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
             "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
-            "dev": true,
             "dependencies": {
                 "glob": "^7.0.0",
                 "interpret": "^1.0.0",
@@ -9084,6 +9003,7 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "dev": true,
             "dependencies": {
                 "safe-buffer": "~5.1.0"
             }
@@ -9254,7 +9174,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
             "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-            "dev": true,
             "engines": {
                 "node": ">= 0.4"
             },
@@ -9777,6 +9696,15 @@
                 "node": ">=8"
             }
         },
+        "node_modules/truncate-utf8-bytes": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+            "integrity": "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==",
+            "license": "WTFPL",
+            "dependencies": {
+                "utf8-byte-length": "^1.0.1"
+            }
+        },
         "node_modules/ts-jest": {
             "version": "27.1.3",
             "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-27.1.3.tgz",
@@ -10016,11 +9944,6 @@
                 "node": ">= 16.0.0"
             }
         },
-        "node_modules/typedarray": {
-            "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-            "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
-        },
         "node_modules/typedarray-to-buffer": {
             "version": "3.1.5",
             "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
@@ -10083,10 +10006,17 @@
                 "querystring": "0.2.0"
             }
         },
+        "node_modules/utf8-byte-length": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
+            "integrity": "sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==",
+            "license": "(WTFPL OR MIT)"
+        },
         "node_modules/util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+            "dev": true
         },
         "node_modules/util.promisify": {
             "version": "1.0.1",
@@ -10466,8 +10396,7 @@
         "node_modules/wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-            "dev": true
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "node_modules/write-file-atomic": {
             "version": "3.0.3",
@@ -12368,9 +12297,9 @@
             "dev": true
         },
         "adm-zip": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.3.tgz",
-            "integrity": "sha512-zsoTXEwRNCxBzRHLENFLuecCcwzzXiEhWo1r3GP68iwi8Q/hW2RrqgeY1nfJ/AhNQNWnZq/4v0TbfMsUkI+TYw=="
+            "version": "0.5.16",
+            "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
+            "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ=="
         },
         "agent-base": {
             "version": "6.0.2",
@@ -12491,11 +12420,6 @@
             "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
             "dev": true
         },
-        "asap": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-            "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
-        },
         "astral-regex": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -12576,87 +12500,23 @@
             }
         },
         "azure-pipelines-task-lib": {
-            "version": "2.12.2",
-            "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-2.12.2.tgz",
-            "integrity": "sha512-ofAdVZcL90Qv6zYcKa1vK3Wnrl2kxoKX/Idvb7RWrqHQzcJlAEjCU4UCB5y6NnSKqRSyVTIhdS6hChphpOaiMQ==",
+            "version": "4.17.3",
+            "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.17.3.tgz",
+            "integrity": "sha512-UxfH5pk3uOHTi9TtLtdDyugQVkFES5A836ZEePjcs3jYyxm3EJ6IlFYq6gbfd6mNBhrM9fxG2u/MFYIJ+Z0cxQ==",
             "requires": {
-                "minimatch": "3.0.4",
-                "mockery": "^1.7.0",
-                "q": "^1.1.2",
-                "semver": "^5.1.0",
-                "shelljs": "^0.3.0",
-                "sync-request": "3.0.1",
+                "adm-zip": "^0.5.10",
+                "minimatch": "3.0.5",
+                "nodejs-file-downloader": "^4.11.1",
+                "q": "^1.5.1",
+                "semver": "^5.7.2",
+                "shelljs": "^0.8.5",
                 "uuid": "^3.0.1"
             },
             "dependencies": {
-                "caseless": {
-                    "version": "0.11.0",
-                    "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-                    "integrity": "sha512-ODLXH644w9C2fMPAm7bMDQ3GRvipZWZfKc+8As6hIadRIelE0n0xZuN38NS6kiK3KPEVrpymmQD8bvncAHWQkQ=="
-                },
-                "http-basic": {
-                    "version": "2.5.1",
-                    "resolved": "https://registry.npmjs.org/http-basic/-/http-basic-2.5.1.tgz",
-                    "integrity": "sha512-q/qOkgjcnZ90v0wSaMwamhfAhIf6lhOsH0ehHFnQHAt1lA9MedSnmqEEnh8bq0njTBAK3IsmS2gEuXryfWCDkw==",
-                    "requires": {
-                        "caseless": "~0.11.0",
-                        "concat-stream": "^1.4.6",
-                        "http-response-object": "^1.0.0"
-                    }
-                },
-                "http-response-object": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-1.1.0.tgz",
-                    "integrity": "sha512-adERueQxEMtIfGk4ee/9CG7AGUjS09OyHeKrubTjmHUsEVXesrGlZLWYnCL8fajPZIX9H4NDnXyyzBPrF078sA=="
-                },
-                "minimatch": {
-                    "version": "3.0.4",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-                    "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-                    "requires": {
-                        "brace-expansion": "^1.1.7"
-                    }
-                },
-                "promise": {
-                    "version": "7.3.1",
-                    "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-                    "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-                    "requires": {
-                        "asap": "~2.0.3"
-                    }
-                },
                 "semver": {
-                    "version": "5.7.1",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                },
-                "shelljs": {
-                    "version": "0.3.0",
-                    "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
-                    "integrity": "sha512-Ny0KN4dyT8ZSCE0frtcbAJGoM/HTArpyPkeli1/00aYfm0sbD/Gk/4x7N2DP9QKGpBsiQH7n6rpm1L79RtviEQ=="
-                },
-                "sync-request": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/sync-request/-/sync-request-3.0.1.tgz",
-                    "integrity": "sha512-bnOSypECs6aB9ScWHcJAkS9z55jOhO3tdLefLfJ+J58vC2HCi5tjxmFMxLv0RxvuAFFQ/G4BupVehqpAlbi+3Q==",
-                    "requires": {
-                        "concat-stream": "^1.4.7",
-                        "http-response-object": "^1.0.1",
-                        "then-request": "^2.0.1"
-                    }
-                },
-                "then-request": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/then-request/-/then-request-2.2.0.tgz",
-                    "integrity": "sha512-YM/Fho1bQ3JFX9dgFQsBswc3aSTePXvtNHl3aXJTZNz/444yC86EVJR92aWMRNA0O9X0UfmojyCTUcT8Lbo5yA==",
-                    "requires": {
-                        "caseless": "~0.11.0",
-                        "concat-stream": "^1.4.7",
-                        "http-basic": "^2.5.1",
-                        "http-response-object": "^1.1.0",
-                        "promise": "^7.1.1",
-                        "qs": "^6.1.0"
-                    }
+                    "version": "5.7.2",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+                    "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="
                 }
             }
         },
@@ -12892,7 +12752,8 @@
         "buffer-from": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-            "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+            "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+            "dev": true
         },
         "call-bind": {
             "version": "1.0.2",
@@ -13108,17 +12969,6 @@
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
-        "concat-stream": {
-            "version": "1.6.2",
-            "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-            "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-            "requires": {
-                "buffer-from": "^1.0.0",
-                "inherits": "^2.0.3",
-                "readable-stream": "^2.2.2",
-                "typedarray": "^0.0.6"
-            }
-        },
         "convert-source-map": {
             "version": "1.8.0",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
@@ -13131,7 +12981,8 @@
         "core-util-is": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+            "dev": true
         },
         "cosmiconfig": {
             "version": "7.0.1",
@@ -14153,8 +14004,7 @@
         "follow-redirects": {
             "version": "1.15.6",
             "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-            "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
-            "dev": true
+            "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA=="
         },
         "fs-constants": {
             "version": "1.0.0",
@@ -14176,8 +14026,7 @@
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-            "dev": true
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
         "fsevents": {
             "version": "2.3.2",
@@ -14241,7 +14090,6 @@
             "version": "7.1.4",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
             "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-            "dev": true,
             "requires": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -14540,7 +14388,6 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-            "dev": true,
             "requires": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -14554,8 +14401,7 @@
         "interpret": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-            "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
-            "dev": true
+            "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="
         },
         "is-arrayish": {
             "version": "0.2.1",
@@ -14573,7 +14419,6 @@
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
             "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
-            "dev": true,
             "requires": {
                 "has": "^1.0.3"
             }
@@ -16391,7 +16236,6 @@
             "version": "3.0.5",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
             "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
-            "dev": true,
             "requires": {
                 "brace-expansion": "^1.1.7"
             }
@@ -16418,11 +16262,6 @@
             "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
             "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
             "dev": true
-        },
-        "mockery": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/mockery/-/mockery-1.7.0.tgz",
-            "integrity": "sha1-9O3g2HUMHJcnwnLqLGBiniyaHE8="
         },
         "mri": {
             "version": "1.1.4",
@@ -16486,6 +16325,17 @@
             "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.2.tgz",
             "integrity": "sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg==",
             "dev": true
+        },
+        "nodejs-file-downloader": {
+            "version": "4.13.0",
+            "resolved": "https://registry.npmjs.org/nodejs-file-downloader/-/nodejs-file-downloader-4.13.0.tgz",
+            "integrity": "sha512-nI2fKnmJWWFZF6SgMPe1iBodKhfpztLKJTtCtNYGhm/9QXmWa/Pk9Sv00qHgzEvNLe1x7hjGDRor7gcm/ChaIQ==",
+            "requires": {
+                "follow-redirects": "^1.15.6",
+                "https-proxy-agent": "^5.0.0",
+                "mime-types": "^2.1.27",
+                "sanitize-filename": "^1.6.3"
+            }
         },
         "normalize-package-data": {
             "version": "2.5.0",
@@ -16587,7 +16437,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-            "dev": true,
             "requires": {
                 "wrappy": "1"
             }
@@ -16711,8 +16560,7 @@
         "path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-            "dev": true
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
         },
         "path-key": {
             "version": "2.0.1",
@@ -16723,8 +16571,7 @@
         "path-parse": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-            "dev": true
+            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
         },
         "path-type": {
             "version": "4.0.0",
@@ -16869,7 +16716,8 @@
         "process-nextick-args": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-            "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+            "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+            "dev": true
         },
         "progress": {
             "version": "2.0.3",
@@ -17022,6 +16870,7 @@
             "version": "2.3.6",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
             "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+            "dev": true,
             "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -17042,7 +16891,6 @@
             "version": "0.6.2",
             "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
             "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-            "dev": true,
             "requires": {
                 "resolve": "^1.1.6"
             }
@@ -17085,7 +16933,6 @@
             "version": "1.22.0",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
             "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
-            "dev": true,
             "requires": {
                 "is-core-module": "^2.8.1",
                 "path-parse": "^1.0.7",
@@ -17152,13 +16999,22 @@
         "safe-buffer": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "dev": true
         },
         "safer-buffer": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
             "dev": true
+        },
+        "sanitize-filename": {
+            "version": "1.6.3",
+            "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
+            "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
+            "requires": {
+                "truncate-utf8-bytes": "^1.0.0"
+            }
         },
         "sax": {
             "version": "1.2.1",
@@ -17251,7 +17107,6 @@
             "version": "0.8.5",
             "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
             "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
-            "dev": true,
             "requires": {
                 "glob": "^7.0.0",
                 "interpret": "^1.0.0",
@@ -17402,6 +17257,7 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "dev": true,
             "requires": {
                 "safe-buffer": "~5.1.0"
             }
@@ -17528,8 +17384,7 @@
         "supports-preserve-symlinks-flag": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-            "dev": true
+            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
         },
         "symbol-tree": {
             "version": "3.2.4",
@@ -17942,6 +17797,14 @@
             "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
             "dev": true
         },
+        "truncate-utf8-bytes": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+            "integrity": "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==",
+            "requires": {
+                "utf8-byte-length": "^1.0.1"
+            }
+        },
         "ts-jest": {
             "version": "27.1.3",
             "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-27.1.3.tgz",
@@ -18093,11 +17956,6 @@
                 "underscore": "^1.12.1"
             }
         },
-        "typedarray": {
-            "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-            "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
-        },
         "typedarray-to-buffer": {
             "version": "3.1.5",
             "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
@@ -18149,10 +18007,16 @@
                 "querystring": "0.2.0"
             }
         },
+        "utf8-byte-length": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
+            "integrity": "sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA=="
+        },
         "util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+            "dev": true
         },
         "util.promisify": {
             "version": "1.0.1",
@@ -18449,8 +18313,7 @@
         "wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-            "dev": true
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "write-file-atomic": {
             "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
         "adm-zip": "^0.5.3",
         "aws-sdk": "^2.979.0",
         "azure-devops-node-api": "^14.0.1",
-        "azure-pipelines-task-lib": "^2.12.2",
+        "azure-pipelines-task-lib": "^4.17.3",
         "base-64": "^0.1.0",
         "https-proxy-agent": "^5.0.0",
         "js-yaml": "^3.13.1",

--- a/src/tasks/AWSCLI/task.json
+++ b/src/tasks/AWSCLI/task.json
@@ -76,6 +76,10 @@
         "Node10": {
             "target": "AWSCLI.js",
             "argumentFormat": ""
+        },
+        "Node20_1": {
+            "target": "AWSCLI.js",
+            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/AWSShellScript/task.json
+++ b/src/tasks/AWSShellScript/task.json
@@ -115,6 +115,10 @@
         "Node10": {
             "target": "AWSShellScript.js",
             "argumentFormat": ""
+        },
+        "Node20_1": {
+            "target": "AWSShellScript.js",
+            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/BeanstalkCreateApplicationVersion/task.json
+++ b/src/tasks/BeanstalkCreateApplicationVersion/task.json
@@ -143,6 +143,10 @@
         "Node10": {
             "target": "BeanstalkCreateApplicationVersion.js",
             "argumentFormat": ""
+        },
+        "Node20_1": {
+            "target": "BeanstalkCreateApplicationVersion.js",
+            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/BeanstalkDeployApplication/task.json
+++ b/src/tasks/BeanstalkDeployApplication/task.json
@@ -160,6 +160,10 @@
         "Node10": {
             "target": "BeanstalkDeployApplication.js",
             "argumentFormat": ""
+        },
+        "Node20_1": {
+            "target": "BeanstalkDeployApplication.js",
+            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/CloudFormationCreateOrUpdateStack/task.json
+++ b/src/tasks/CloudFormationCreateOrUpdateStack/task.json
@@ -380,6 +380,10 @@
         "Node10": {
             "target": "CloudFormationCreateOrUpdateStack.js",
             "argumentFormat": ""
+        },
+        "Node20_1": {
+            "target": "CloudFormationCreateOrUpdateStack.js",
+            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/CloudFormationDeleteStack/task.json
+++ b/src/tasks/CloudFormationDeleteStack/task.json
@@ -70,6 +70,10 @@
         "Node10": {
             "target": "CloudFormationDeleteStack.js",
             "argumentFormat": ""
+        },
+        "Node20_1": {
+            "target": "CloudFormationDeleteStack.js",
+            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/CloudFormationExecuteChangeSet/task.json
+++ b/src/tasks/CloudFormationExecuteChangeSet/task.json
@@ -133,6 +133,10 @@
         "Node10": {
             "target": "CloudFormationExecuteChangeSet.js",
             "argumentFormat": ""
+        },
+        "Node20_1": {
+            "target": "CloudFormationExecuteChangeSet.js",
+            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/CodeDeployDeployApplication/task.json
+++ b/src/tasks/CodeDeployDeployApplication/task.json
@@ -207,6 +207,10 @@
         "Node10": {
             "target": "CodeDeployDeployApplication.js",
             "argumentFormat": ""
+        },
+        "Node20_1": {
+            "target": "CodeDeployDeployApplication.js",
+            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/ECRPullImage/task.json
+++ b/src/tasks/ECRPullImage/task.json
@@ -116,6 +116,10 @@
         "Node10": {
             "target": "ECRPullImage.js",
             "argumentFormat": ""
+        },
+        "Node20_1": {
+            "target": "ECRPullImage.js",
+            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/ECRPushImage/task.json
+++ b/src/tasks/ECRPushImage/task.json
@@ -157,6 +157,10 @@
         "Node10": {
             "target": "ECRPushImage.js",
             "argumentFormat": ""
+        },
+        "Node20_1": {
+            "target": "ECRPushImage.js",
+            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/LambdaDeployFunction/task.json
+++ b/src/tasks/LambdaDeployFunction/task.json
@@ -306,6 +306,10 @@
         "Node10": {
             "target": "LambdaDeployFunction.js",
             "argumentFormat": ""
+        },
+        "Node20_1": {
+            "target": "LambdaDeployFunction.js",
+            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/LambdaInvokeFunction/task.json
+++ b/src/tasks/LambdaInvokeFunction/task.json
@@ -113,6 +113,10 @@
         "Node10": {
             "target": "LambdaInvokeFunction.js",
             "argumentFormat": ""
+        },
+        "Node20_1": {
+            "target": "LambdaInvokeFunction.js",
+            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/LambdaNETCoreDeploy/task.json
+++ b/src/tasks/LambdaNETCoreDeploy/task.json
@@ -176,6 +176,10 @@
         "Node10": {
             "target": "LambdaNETCoreDeploy.js",
             "argumentFormat": ""
+        },
+        "Node20_1": {
+            "target": "LambdaNETCoreDeploy.js",
+            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/S3Download/task.json
+++ b/src/tasks/S3Download/task.json
@@ -153,6 +153,10 @@
         "Node10": {
             "target": "S3Download.js",
             "argumentFormat": ""
+        },
+        "Node20_1": {
+            "target": "S3Download.js",
+            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/S3Upload/task.json
+++ b/src/tasks/S3Upload/task.json
@@ -235,6 +235,10 @@
         "Node10": {
             "target": "S3Upload.js",
             "argumentFormat": ""
+        },
+        "Node20_1": {
+            "target": "S3Upload.js",
+            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/SecretsManagerCreateOrUpdateSecret/task.json
+++ b/src/tasks/SecretsManagerCreateOrUpdateSecret/task.json
@@ -168,6 +168,10 @@
         "Node10": {
             "target": "SecretsManagerCreateOrUpdateSecret.js",
             "argumentFormat": ""
+        },
+        "Node20_1": {
+            "target": "SecretsManagerCreateOrUpdateSecret.js",
+            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/SecretsManagerGetSecret/task.json
+++ b/src/tasks/SecretsManagerGetSecret/task.json
@@ -93,6 +93,10 @@
         "Node10": {
             "target": "SecretsManagerGetSecret.js",
             "argumentFormat": ""
+        },
+        "Node20_1": {
+            "target": "SecretsManagerGetSecret.js",
+            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/SendMessage/task.json
+++ b/src/tasks/SendMessage/task.json
@@ -108,6 +108,10 @@
         "Node10": {
             "target": "SendMessage.js",
             "argumentFormat": ""
+        },
+        "Node20_1": {
+            "target": "SendMessage.js",
+            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/SystemsManagerGetParameter/task.json
+++ b/src/tasks/SystemsManagerGetParameter/task.json
@@ -183,6 +183,10 @@
         "Node10": {
             "target": "SystemsManagerGetParameter.js",
             "argumentFormat": ""
+        },
+        "Node20_1": {
+            "target": "SystemsManagerGetParameter.js",
+            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/SystemsManagerRunCommand/task.json
+++ b/src/tasks/SystemsManagerRunCommand/task.json
@@ -274,6 +274,10 @@
         "Node10": {
             "target": "SystemsManagerRunCommand.js",
             "argumentFormat": ""
+        },
+        "Node20_1": {
+            "target": "SystemsManagerRunCommand.js",
+            "argumentFormat": ""
         }
     },
     "messages": {

--- a/src/tasks/SystemsManagerSetParameter/task.json
+++ b/src/tasks/SystemsManagerSetParameter/task.json
@@ -99,6 +99,10 @@
         "Node10": {
             "target": "SystemsManagerSetParameter.js",
             "argumentFormat": ""
+        },
+        "Node20_1": {
+            "target": "SystemsManagerSetParameter.js",
+            "argumentFormat": ""
         }
     },
     "messages": {


### PR DESCRIPTION
Use Node 20 using microsoft guidance: https://learn.microsoft.com/en-us/azure/devops/extend/develop/add-build-task?view=azure-devops#q-how-can-i-upgrade-my-custom-task-to-the-latest-node

Keep Node 10 as a fallback.

Adding support requires a hacky patch to fix shell.js, which doesn't support bundlers.
Mitigates the issue described in https://github.com/aws/aws-toolkit-azure-devops/pull/539

Addresses https://github.com/aws/aws-toolkit-azure-devops/issues/566

Credit to ivanduplenskikh:  https://github.com/ivanduplenskikh/aws-toolkit-azure-devops/pull/1

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] I have read the **README** document
-   [ ] I have read the **CONTRIBUTING** document
-   [ ] My code follows the code style of this project
-   [ ] I have added tests to cover my changes
-   [ ] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
