### PR TITLE
use the correct OIDC request url for the powershell task

### DIFF
--- a/.changes/next-release/Bug Fix-4c8c9cea-b7f9-407b-b85e-36fdba5fc17b.json
+++ b/.changes/next-release/Bug Fix-4c8c9cea-b7f9-407b-b85e-36fdba5fc17b.json
@@ -1,0 +1,4 @@
+{
+	"type": "Bug Fix",
+	"description": "use the correct OIDC request url for the PowerShell task"
+}

--- a/src/tasks/AWSPowerShellModuleScript/RunAWSPowerShellModuleScript.ps1
+++ b/src/tasks/AWSPowerShellModuleScript/RunAWSPowerShellModuleScript.ps1
@@ -116,7 +116,7 @@ try {
                 }
 
                 # Request an OIDC token for the service connection from the VSTS REST API
-                $url = "$Env:SYSTEM_TEAMFOUNDATIONCOLLECTIONURI$Env:SYSTEM_TEAMPROJECTID/_apis/distributedtask/hubs/build/plans/$Env:SYSTEM_PLANID/jobs/$Env:SYSTEM_JOBID/oidctoken?api-version=7.1-preview.1&serviceConnectionId=$awsEndpoint"
+                $url = $Env:SYSTEM_OIDCREQUESTURI + "?api-version=7.1-preview.1&serviceConnectionId=$awsEndpoint"
                 $response = Invoke-WebRequest -Uri $url -Method POST -Headers $Headers  -Body '{}' -ContentType "application/json" | ConvertFrom-Json
                 $token = $response.oidcToken
 


### PR DESCRIPTION
## Description

The AZDO agents provide a variable which contains the actual URL needed to retrieve the OIDC token  - System.OidcRequestUri
as specified in the documentation: https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml


## Motivation

I could not use the Powershell Module with OIDC authentication in a Release because the OIDC request URL was wrong

## Testing
I manually changed the RunAWSPowerShellModuleScript.ps1 on one of my agents with the changes in this PR and it worked flawlessly.

Unfortunately the variant without explicit string concatenation

$url = "$Env:SYSTEM_OIDCREQUESTURI?api-version=7.1-preview.1&serviceConnectionId=$awsEndpoint" 

didn't work since it seems powershell thinks "?" is part of the variable name, and the substitution failed.(https://stackoverflow.com/questions/66071918/why-does-powershell-not-process-a-string-correctly-which-has-a-dollar-sign-and-a)

## Checklist

-   [x] I have read the **README** document
-   [x] I have read the **CONTRIBUTING** document
-   [x] My code follows the code style of this project
-   [x] I have added tests to cover my changes (no tests needed)
-   [x] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
