### PR TITLE
test: skip NET Core deploy test on mac

### DIFF
--- a/tests/taskTests/lambdaNETCoreDeploy/lambdaNETCoreDeploy-test.ts
+++ b/tests/taskTests/lambdaNETCoreDeploy/lambdaNETCoreDeploy-test.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
+import * as os from 'os'
 import { SdkUtils } from 'lib/sdkutils'
 import { join } from 'path'
 import { TaskOperations } from 'tasks/LambdaNETCoreDeploy/TaskOperations'
@@ -29,6 +30,14 @@ const baseTaskParameters: TaskParameters = {
 const executable = join(__dirname, '../../resources/echo.bat')
 
 describe('Lambda NET Core Deploy', () => {
+    // TODO: Fix this if possible
+    if (os.platform() === 'darwin') {
+        test('Skip Lambda NET Core Deploy suite', () => {
+            console.log('Skipping Lambda NET Core Deploy test on mac')
+        })
+        return
+    }
+
     // TODO https://github.com/aws/aws-toolkit-azure-devops/issues/167
     beforeAll(() => {
         process.env.AWS_REGION = 'region'


### PR DESCRIPTION
It fails on mac during local development due to the bat file that it tries to run. Let's turn it off for local mac development for now.

## License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
