### PR TITLE
fix: use stdin to pass ecr login password

### DIFF
--- a/src/lib/ecrUtils.ts
+++ b/src/lib/ecrUtils.ts
@@ -18,6 +18,15 @@ export async function loginToRegistry(
         .decode(encodedAuthToken)
         .trim()
         .split(':')
+
+    // Mask credentials from logs to prevent accidental exposure
+    if (tokens[0]) {
+        tl.setSecret(tokens[0]) // username
+    }
+    if (tokens[1]) {
+        tl.setSecret(tokens[1]) // password
+    }
+
     await dockerHandler.runDockerCommand(dockerPath, 'login', ['-u', tokens[0], '-p', tokens[1], endpoint], {
         silent: true
     })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Customer report that credentials are printed out in toolkit ECR task.

## Motivation

This could cause unintentionally credential expose.


## Testing

before
<img width="2214" height="1738" alt="image" src="https://github.com/user-attachments/assets/c0bdb62f-a0d9-4c8c-9c9c-d3033c0c1528" />

After
<img width="1417" height="727" alt="image" src="https://github.com/user-attachments/assets/32f33ea6-f3dd-47ad-8c3a-b24a0b354337" />


<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have read the **README** document
-   [x] I have read the **CONTRIBUTING** document
-   [x] My code follows the code style of this project
-   [ ] I have added tests to cover my changes
  - N/A
-   [ ] A short description of the change has been added to the changelog using the script `npm run newChange`
  - N/A

## License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
