### PR TITLE
Attempt to use AWS.Tools.* PowerShell Modules 

### DIFF
--- a/.changes/next-release/Breaking Change-164328cf-e5ba-44d0-9133-9e00214d1af9.json
+++ b/.changes/next-release/Breaking Change-164328cf-e5ba-44d0-9133-9e00214d1af9.json
@@ -1,0 +1,4 @@
+{
+	"type": "Breaking Change",
+	"description": "Use AWS.Tools.* Powershell Modules for AWSPowershellModuleScript if available"
+}

--- a/src/tasks/AWSPowerShellModuleScript/RunAWSPowerShellModuleScript.ps1
+++ b/src/tasks/AWSPowerShellModuleScript/RunAWSPowerShellModuleScript.ps1
@@ -37,8 +37,8 @@ try {
     Write-Host (Get-VstsLocString -Key 'TestingAWSModuleInstalled')
     if (Get-Module -Name AWS.Tools.Common -ListAvailable) {
         Write-Host (Get-VstsLocString -Key 'ModularAWSModuleFound')
-        if((Get-Module -Name AWS.Tools.SecurityToken -ListAvailable)) {
-            Import-Module AWS.Tools.SecurityToken
+        if(Get-Module -Name AWS.Tools.SecurityToken -ListAvailable) {
+            Import-Module -Name AWS.Tools.SecurityToken
         }
         else {
             Write-Host (Get-VstsLocString -Key 'SecurityTokenModuleNotFound')

--- a/src/tasks/AWSPowerShellModuleScript/task.json
+++ b/src/tasks/AWSPowerShellModuleScript/task.json
@@ -132,6 +132,8 @@
     "messages": {
         "GeneratingScript": "Generating script.",
         "TestingAWSModuleInstalled": "Checking install status for AWS Tools for Windows PowerShell module.",
+        "ModularAWSModuleFound": "AWS.Tools.Common found. Assuming all needed AWS.Tools modules are already installed.",
+        "SecurityTokenModuleNotFound": "AWS.Tools.SecurityToken module not found. You will not be able to use a service connection specifying a role ARN.",
         "AWSModuleNotFound": "AWS Tools for Windows PowerShell module not found.",
         "InstallingAWSModule": "Installing AWS Tools for Windows PowerShell module to current user scope",
         "ConfiguringRegionFromTaskConfiguration": "Region discovered from task configuration",


### PR DESCRIPTION
This PR allows using the AWS.Tools powershell modules for the AWSPowershellModuleScript task.

## Description

This PR changes the logic for autoinstalling the AWSPowershell module. Currently, the task will check if the AWSPowershell module is installed, and install it if it isn't. This change makes it so the task first checks for the AWS.Tools.Common module, and if it finds it, it does not attempt to install or import the AWSPowershell module. Additionally, if the AWS.Tools.Common module is found, it will attempt to import the AWS.Tools.SecurityToken module to facilitate role assumption using service connections.

This may break assuming a role via a service connection for agents that have AWS.Tools.Common installed without AWS.Tools.SecurityToken

## Motivation

This allows agents to use the AWS.Tools powershell modules. These are the recommended way to install the AWS powershell cmdlets per [this page](https://docs.aws.amazon.com/powershell/v5/userguide/pstools-getting-set-up-windows.html), and they avoid the excessive load times seen with the monolithic modules.

## Related Issue(s), If Filed

fixes #366 and fixes #520  

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have read the **README** document
-   [x] I have read the **CONTRIBUTING** document
-   [x] My code follows the code style of this project
-   [-] I have added tests to cover my changes
-   [x] A short description of the change has been added to the changelog using the script `npm run newChange`

## License

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
